### PR TITLE
Wrong options for cellular signal helper function <sysmode>

### DIFF
--- a/modules/bg96/cellular_bg96_api.c
+++ b/modules/bg96/cellular_bg96_api.c
@@ -237,8 +237,8 @@ static bool _parseSignalQuality( char * pQcsqPayload,
     if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         if( ( strcmp( pToken, "GSM" ) != 0 ) &&
-            ( strcmp( pToken, "CAT-M1" ) != 0 ) &&
-            ( strcmp( pToken, "CAT-NB1" ) != 0 ) )
+            ( strcmp( pToken, "eMTC" ) != 0 ) &&
+            ( strcmp( pToken, "NBIoT" ) != 0 ) )
         {
             parseStatus = false;
         }


### PR DESCRIPTION
Correct options are "NOSERVICE","GSM","eMTC","NBIoT"
See: BG95&BG77&BG600L Series AT Commands Manual - Section 6.16. AT+QCSQ Query and Report Signal Strength