### PR TITLE
Fix compile warnings

### DIFF
--- a/modules/sara_r4/cellular_r4_api.c
+++ b/modules/sara_r4/cellular_r4_api.c
@@ -71,7 +71,7 @@
                                                                                              #define USOCR_PROTOCOL_TCP                            ( 6U )
                                                                                              #define USOCR_PROTOCOL_UDP                            ( 17U )
                                                                                              *
-                                                                                             * /*-----------------------------------------------------------*/
+                                                                                             *-----------------------------------------------------------*/
 #define RAT_PRIOIRTY_LIST_LENGTH                ( 3U )
 
 /**
@@ -231,8 +231,8 @@ static CellularATError_t getDataFromResp( const CellularATCommandResponse_t * pA
     /* Check if the received data size is greater than the output buffer size. */
     if( *pDataRecv->pDataLen > outBufSize )
     {
-        LogError( ( "Data is turncated, received data length %d, out buffer size %d",
-                    *pDataRecv->pDataLen, outBufSize ) );
+        LogError( ( "Data is turncated, received data length %u, out buffer size %u",
+                    (unsigned)*pDataRecv->pDataLen, (unsigned)outBufSize ) );
         dataLenToCopy = outBufSize;
         *pDataRecv->pDataLen = outBufSize;
     }
@@ -253,8 +253,8 @@ static CellularATError_t getDataFromResp( const CellularATCommandResponse_t * pA
         }
         else
         {
-            LogError( ( "Receive Data: paramerter error, data pointer %p, data to copy %d",
-                        pInputLine, dataLenToCopy ) );
+            LogError( ( "Receive Data: paramerter error, data pointer %p, data to copy %u",
+                        pInputLine, (unsigned)dataLenToCopy ) );
             atCoreStatus = CELLULAR_AT_BAD_PARAMETER;
         }
     }
@@ -820,7 +820,7 @@ CellularError_t Cellular_SocketClose( CellularHandle_t cellularHandle,
         if( socketHandle->socketState == SOCKETSTATE_CONNECTED )
         {
             ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%s%u,%d",
-                               "AT+USOCL=", sessionId, CELLULAR_CONFIG_SET_SOCKET_CLOSE_ASYNC_MODE );
+                               "AT+USOCL=", (unsigned)sessionId, CELLULAR_CONFIG_SET_SOCKET_CLOSE_ASYNC_MODE );
             pktStatus = _Cellular_TimeoutAtcmdRequestWithCallback( pContext, atReqSocketClose, SOCKET_CLOSE_PACKET_REQ_TIMEOUT_MS );
 
             /* Delete the socket config. */
@@ -903,7 +903,7 @@ CellularError_t Cellular_SocketConnect( CellularHandle_t cellularHandle,
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             /* Store the session ID in the pointer directly instead allocate extra memory. */
-            socketHandle->pModemData = ( void * ) sessionId;
+            socketHandle->pModemData = ( void * ) (uintptr_t)sessionId;
 
             /* Create the reverse table to store the socketIndex to sessionId. */
             pModuleContext->pSessionMap[ sessionId ] = socketHandle->socketId;
@@ -914,7 +914,7 @@ CellularError_t Cellular_SocketConnect( CellularHandle_t cellularHandle,
     if( cellularStatus == CELLULAR_SUCCESS )
     {
         /*
-         * /* The return value of snprintf is not used.
+         * The return value of snprintf is not used.
          * The max length of the string is fixed and checked offline. */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
         ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE,

--- a/modules/sara_r4/cellular_r4_api.c
+++ b/modules/sara_r4/cellular_r4_api.c
@@ -232,7 +232,7 @@ static CellularATError_t getDataFromResp( const CellularATCommandResponse_t * pA
     if( *pDataRecv->pDataLen > outBufSize )
     {
         LogError( ( "Data is turncated, received data length %u, out buffer size %u",
-                    (unsigned)*pDataRecv->pDataLen, (unsigned)outBufSize ) );
+                    ( unsigned ) *pDataRecv->pDataLen, ( unsigned ) outBufSize ) );
         dataLenToCopy = outBufSize;
         *pDataRecv->pDataLen = outBufSize;
     }
@@ -254,7 +254,7 @@ static CellularATError_t getDataFromResp( const CellularATCommandResponse_t * pA
         else
         {
             LogError( ( "Receive Data: paramerter error, data pointer %p, data to copy %u",
-                        pInputLine, (unsigned)dataLenToCopy ) );
+                        pInputLine, ( unsigned ) dataLenToCopy ) );
             atCoreStatus = CELLULAR_AT_BAD_PARAMETER;
         }
     }
@@ -820,7 +820,7 @@ CellularError_t Cellular_SocketClose( CellularHandle_t cellularHandle,
         if( socketHandle->socketState == SOCKETSTATE_CONNECTED )
         {
             ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%s%u,%d",
-                               "AT+USOCL=", (unsigned)sessionId, CELLULAR_CONFIG_SET_SOCKET_CLOSE_ASYNC_MODE );
+                               "AT+USOCL=", ( unsigned ) sessionId, CELLULAR_CONFIG_SET_SOCKET_CLOSE_ASYNC_MODE );
             pktStatus = _Cellular_TimeoutAtcmdRequestWithCallback( pContext, atReqSocketClose, SOCKET_CLOSE_PACKET_REQ_TIMEOUT_MS );
 
             /* Delete the socket config. */
@@ -903,7 +903,7 @@ CellularError_t Cellular_SocketConnect( CellularHandle_t cellularHandle,
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             /* Store the session ID in the pointer directly instead allocate extra memory. */
-            socketHandle->pModemData = ( void * ) (uintptr_t)sessionId;
+            socketHandle->pModemData = ( void * ) ( uintptr_t ) sessionId;
 
             /* Create the reverse table to store the socketIndex to sessionId. */
             pModuleContext->pSessionMap[ sessionId ] = socketHandle->socketId;

--- a/modules/sara_r4/cellular_r4_urc_handler.c
+++ b/modules/sara_r4/cellular_r4_urc_handler.c
@@ -433,12 +433,12 @@ static void _cellular_UrcProcessUusoco( CellularContext_t * pContext,
 
             if( pSocketData == NULL )
             {
-                LogError( ( "_cellular_UrcProcessUusoco : invalid socket index %u", (unsigned)socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusoco : invalid socket index %u", ( unsigned ) socketIndex ) );
             }
-            else if( pSocketData->pModemData != ( void * ) (intptr_t)sessionId )
+            else if( pSocketData->pModemData != ( void * ) ( intptr_t ) sessionId )
             {
                 LogError( ( "_cellular_UrcProcessUusoco : session not match %u socket index %u",
-                            ( uintptr_t ) pSocketData->pModemData, (unsigned)socketIndex ) );
+                            ( uintptr_t ) pSocketData->pModemData, ( unsigned ) socketIndex ) );
             }
             else
             {
@@ -512,12 +512,12 @@ static void _cellular_UrcProcessUusord( CellularContext_t * pContext,
 
             if( pSocketData == NULL )
             {
-                LogError( ( "_cellular_UrcProcessUusord : invalid socket index %u", (unsigned)socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusord : invalid socket index %u", ( unsigned ) socketIndex ) );
             }
-            else if( pSocketData->pModemData != ( void * ) (uintptr_t)sessionId )
+            else if( pSocketData->pModemData != ( void * ) ( uintptr_t ) sessionId )
             {
                 LogError( ( "_cellular_UrcProcessUusord : session not match %u socket index %u",
-                            ( uintptr_t ) pSocketData->pModemData, (unsigned)socketIndex ) );
+                            ( uintptr_t ) pSocketData->pModemData, ( unsigned ) socketIndex ) );
             }
             else
             {
@@ -579,12 +579,12 @@ static void _cellular_UrcProcessUusocl( CellularContext_t * pContext,
 
             if( pSocketData == NULL )
             {
-                LogError( ( "_cellular_UrcProcessUusocl : invalid socket index %u", (unsigned)socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusocl : invalid socket index %u", ( unsigned ) socketIndex ) );
             }
-            else if( pSocketData->pModemData != ( void * ) (uintptr_t)sessionId )
+            else if( pSocketData->pModemData != ( void * ) ( uintptr_t ) sessionId )
             {
                 LogError( ( "_cellular_UrcProcessUusocl : session not match %u socket index %u",
-                            ( uintptr_t ) pSocketData->pModemData, (unsigned)socketIndex ) );
+                            ( uintptr_t ) pSocketData->pModemData, ( unsigned ) socketIndex ) );
             }
             else
             {

--- a/modules/sara_r4/cellular_r4_urc_handler.c
+++ b/modules/sara_r4/cellular_r4_urc_handler.c
@@ -433,12 +433,12 @@ static void _cellular_UrcProcessUusoco( CellularContext_t * pContext,
 
             if( pSocketData == NULL )
             {
-                LogError( ( "_cellular_UrcProcessUusoco : invalid socket index %d", socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusoco : invalid socket index %u", (unsigned)socketIndex ) );
             }
-            else if( pSocketData->pModemData != ( void * ) sessionId )
+            else if( pSocketData->pModemData != ( void * ) (intptr_t)sessionId )
             {
-                LogError( ( "_cellular_UrcProcessUusoco : session not match %d socket index %d",
-                            ( uint32_t ) pSocketData->pModemData, socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusoco : session not match %u socket index %u",
+                            ( uintptr_t ) pSocketData->pModemData, (unsigned)socketIndex ) );
             }
             else
             {
@@ -512,12 +512,12 @@ static void _cellular_UrcProcessUusord( CellularContext_t * pContext,
 
             if( pSocketData == NULL )
             {
-                LogError( ( "_cellular_UrcProcessUusord : invalid socket index %d", socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusord : invalid socket index %u", (unsigned)socketIndex ) );
             }
-            else if( pSocketData->pModemData != ( void * ) sessionId )
+            else if( pSocketData->pModemData != ( void * ) (uintptr_t)sessionId )
             {
-                LogError( ( "_cellular_UrcProcessUusord : session not match %d socket index %d",
-                            ( uint32_t ) pSocketData->pModemData, socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusord : session not match %u socket index %u",
+                            ( uintptr_t ) pSocketData->pModemData, (unsigned)socketIndex ) );
             }
             else
             {
@@ -579,12 +579,12 @@ static void _cellular_UrcProcessUusocl( CellularContext_t * pContext,
 
             if( pSocketData == NULL )
             {
-                LogError( ( "_cellular_UrcProcessUusocl : invalid socket index %d", socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusocl : invalid socket index %u", (unsigned)socketIndex ) );
             }
-            else if( pSocketData->pModemData != ( void * ) sessionId )
+            else if( pSocketData->pModemData != ( void * ) (uintptr_t)sessionId )
             {
-                LogError( ( "_cellular_UrcProcessUusocl : session not match %d socket index %d",
-                            ( uint32_t ) pSocketData->pModemData, socketIndex ) );
+                LogError( ( "_cellular_UrcProcessUusocl : session not match %u socket index %u",
+                            ( uintptr_t ) pSocketData->pModemData, (unsigned)socketIndex ) );
             }
             else
             {

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -596,7 +596,7 @@ CellularError_t _Cellular_RemoveSocketData( CellularContext_t * pContext,
 
     if( socketHandle->socketState == SOCKETSTATE_CONNECTING )
     {
-        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%d]", socketHandle->socketId ) );
+        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%u]", (unsigned)socketHandle->socketId ) );
     }
 
     taskENTER_CRITICAL();
@@ -649,7 +649,7 @@ CellularError_t _Cellular_IsValidSocket( const CellularContext_t * pContext,
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %d", sockIndex ) );
+            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %u", (unsigned)sockIndex ) );
             cellularStatus = CELLULAR_BAD_PARAMETER;
         }
     }
@@ -913,7 +913,7 @@ CellularSocketContext_t * _Cellular_GetSocketData( const CellularContext_t * pCo
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_GetSocketData, invalid socket handle %d", sockIndex ) );
+            LogError( ( "_Cellular_GetSocketData, invalid socket handle %u", (unsigned)sockIndex ) );
         }
         else
         {

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -596,7 +596,7 @@ CellularError_t _Cellular_RemoveSocketData( CellularContext_t * pContext,
 
     if( socketHandle->socketState == SOCKETSTATE_CONNECTING )
     {
-        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%u]", (unsigned)socketHandle->socketId ) );
+        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%u]", ( unsigned ) socketHandle->socketId ) );
     }
 
     taskENTER_CRITICAL();
@@ -649,7 +649,7 @@ CellularError_t _Cellular_IsValidSocket( const CellularContext_t * pContext,
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %u", (unsigned)sockIndex ) );
+            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %u", ( unsigned ) sockIndex ) );
             cellularStatus = CELLULAR_BAD_PARAMETER;
         }
     }
@@ -913,7 +913,7 @@ CellularSocketContext_t * _Cellular_GetSocketData( const CellularContext_t * pCo
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_GetSocketData, invalid socket handle %u", (unsigned)sockIndex ) );
+            LogError( ( "_Cellular_GetSocketData, invalid socket handle %u", ( unsigned ) sockIndex ) );
         }
         else
         {

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -190,7 +190,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
         else
         {
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
-            LogWarn( ( "Couldn't allocate memory of %lu for urc", (unsigned long)strlen( pBuf ) ) );
+            LogWarn( ( "Couldn't allocate memory of %lu for urc", ( unsigned long ) strlen( pBuf ) ) );
         }
     }
     else
@@ -731,7 +731,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %u: %d %s %s", (unsigned)i, (int)result,
+                LogError( ( "AtParseFail for %u: %d %s %s", ( unsigned ) i, ( int ) result,
                             pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -190,7 +190,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
         else
         {
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
-            LogWarn( ( "Couldn't allocate memory of %lu for urc", strlen( pBuf ) ) );
+            LogWarn( ( "Couldn't allocate memory of %lu for urc", (unsigned long)strlen( pBuf ) ) );
         }
     }
     else
@@ -731,7 +731,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %u: %d %s %s", i, result,
+                LogError( ( "AtParseFail for %u: %d %s %s", (unsigned)i, (int)result,
                             pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }


### PR DESCRIPTION
```
../Lib/FreeRTOS-Cellular-Interface/source/cellular_pkthandler.c:193:24: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'size_t' {aka 'unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/source/cellular_pkthandler.c:734:29: warning: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/source/cellular_pkthandler.c:734:29: warning: format '%d' expects argument of type 'int', but argument 3 has type 'int32_t' {aka 'long int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/source/cellular_common.c:599:20: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/source/cellular_common.c:652:25: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/source/cellular_common.c:916:25: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:74:96: warning: "/*" within comment [-Wcomment]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:234:21: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:234:21: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:256:25: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:822:78: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:906:40: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_api.c:917:12: warning: "/*" within comment [-Wcomment]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:436:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:438:49: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:440:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'long unsigned int' [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:515:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:517:49: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:519:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'long unsigned int' [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:582:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:584:49: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
../Lib/FreeRTOS-Cellular-Interface/modules/sara_r4/cellular_r4_urc_handler.c:586:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'long unsigned int' [-Wformat=]
```