### PR TITLE
Restore URC string when using generic URC callback

### DIFF
--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -489,13 +489,15 @@ static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
     {
         /* No URC callback function available, check for generic call back. */
         LogDebug( ( "No URC Callback func avail %s, now trying generic URC Callback", pTokenPtr ) );
-        if (pSavePtr != pTokenPtr)
+
+        if( pSavePtr != pTokenPtr )
         {
             /* pSavePtr != pTokenPtr means the string starts with '+'.
              * Restore string to "+pTokenPtr:pSavePtr" for callback function. */
-            pTokenPtr--; 
-            *(pSavePtr-1) = ':';
+            pTokenPtr--;
+            *( pSavePtr - 1 ) = ':';
         }
+
         _Cellular_ProcessGenericUrc( pContext, pSavePtr );
     }
 

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -489,6 +489,13 @@ static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
     {
         /* No URC callback function available, check for generic call back. */
         LogDebug( ( "No URC Callback func avail %s, now trying generic URC Callback", pTokenPtr ) );
+        if (pSavePtr != pTokenPtr)
+        {
+            /* pSavePtr != pTokenPtr means the string starts with '+'.
+             * Restore string to "+pTokenPtr:pSavePtr" for callback function. */
+            pTokenPtr--; 
+            *(pSavePtr-1) = ':';
+        }
         _Cellular_ProcessGenericUrc( pContext, pSavePtr );
     }
 

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -498,7 +498,7 @@ static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
             *( pSavePtr - 1 ) = ':';
         }
 
-        _Cellular_ProcessGenericUrc( pContext, pSavePtr );
+        _Cellular_ProcessGenericUrc( pContext, pTokenPtr );
     }
 
     return pktStatus;

--- a/test/unit-test/cellular_pkthandler_utest.c
+++ b/test/unit-test/cellular_pkthandler_utest.c
@@ -621,6 +621,23 @@ void test__Cellular_HandlePacket_Wrong_RespType( void )
 }
 
 /**
+ * @brief Test that URC with colon for _Cellular_HandlePacket when token is not in the token table.
+ */
+void test__Cellular_HandlePacket_AT_UNSOLICITED_Input_String_With_Colon_Not_In_Urc_Token_Path( void )
+{
+    CellularContext_t context;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+
+    memset( &context, 0, sizeof( CellularContext_t ) );
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTableWoParseFunc, sizeof( CellularTokenTable_t ) );
+    Cellular_ATStrDup_StubWithCallback( _CMOCK_Cellular_ATStrDup_CALLBACK );
+    _Cellular_GenericCallback_Ignore();
+    pktStatus = _Cellular_HandlePacket( &context, AT_UNSOLICITED, CELLULAR_AT_MULTI_DATA_WO_PREFIX_STRING_RESP );
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+}
+
+/**
  * @brief Test that null Context case for _Cellular_PktHandler_AtcmdRequestWithCallback.
  */
 void test__Cellular_PktHandler_AtcmdRequestWithCallback_NULL_Context( void )
@@ -1455,22 +1472,5 @@ void test__Cellular_AtcmdRequestSuccessToken_Cellular_PktioSendAtCmd_Return_OK( 
     /* xQueueReceive true, and the data is CELLULAR_PKT_STATUS_OK. */
     queueData = CELLULAR_PKT_STATUS_OK;
     pktStatus = _Cellular_AtcmdRequestSuccessToken( &context, atReqGetMccMnc, PACKET_REQ_TIMEOUT_MS, successTokenTable, 1 );
-    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
-}
-
-/**
- * @brief Test that happy path case for _Cellular_HandlePacket if token is not in the tokenTable.
- */
-void test__Cellular_HandlePacket_AT_UNSOLICITED_Input_String_With_Colon_Not_In_Urc_Token_Path( void )
-{
-    CellularContext_t context;
-    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
-
-    memset( &context, 0, sizeof( CellularContext_t ) );
-    /* copy the token table. */
-    ( void ) memcpy( &context.tokenTable, &tokenTableWoParseFunc, sizeof( CellularTokenTable_t ) );
-    Cellular_ATStrDup_StubWithCallback( _CMOCK_Cellular_ATStrDup_CALLBACK );
-    _Cellular_GenericCallback_Ignore();
-    pktStatus = _Cellular_HandlePacket( &context, AT_UNSOLICITED, CELLULAR_AT_MULTI_DATA_WO_PREFIX_STRING_RESP );
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 }

--- a/test/unit-test/cellular_pkthandler_utest.c
+++ b/test/unit-test/cellular_pkthandler_utest.c
@@ -46,7 +46,7 @@
 #include "mock_cellular_common.h"
 #include "mock_cellular_pktio_internal.h"
 
-#define CELLULAR_AT_MULTI_DATA_WO_PREFIX_STRING_RESP    "+QIRD: 32r123243154354364576587utrhfgdghfg"
+#define CELLULAR_AT_MULTI_DATA_WO_PREFIX_STRING_RESP    "+QIRD: 32\r123243154354364576587utrhfgdghfg"
 #define CELLULAR_URC_TOKEN_STRING_INPUT                 "RDY"
 #define CELLULAR_URC_TOKEN_STRING_INPUT_START_PLUS      "+RDY"
 #define CELLULAR_URC_TOKEN_STRING_GREATER_INPUT         "RDYY"

--- a/test/unit-test/cellular_pkthandler_utest.c
+++ b/test/unit-test/cellular_pkthandler_utest.c
@@ -1457,3 +1457,20 @@ void test__Cellular_AtcmdRequestSuccessToken_Cellular_PktioSendAtCmd_Return_OK( 
     pktStatus = _Cellular_AtcmdRequestSuccessToken( &context, atReqGetMccMnc, PACKET_REQ_TIMEOUT_MS, successTokenTable, 1 );
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 }
+
+/**
+ * @brief Test that happy path case for _Cellular_HandlePacket if token is not in the tokenTable.
+ */
+void test__Cellular_HandlePacket_AT_UNSOLICITED_Input_String_With_Colon_Not_In_Urc_Token_Path( void )
+{
+    CellularContext_t context;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+
+    memset( &context, 0, sizeof( CellularContext_t ) );
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTableWoParseFunc, sizeof( CellularTokenTable_t ) );
+    Cellular_ATStrDup_StubWithCallback( _CMOCK_Cellular_ATStrDup_CALLBACK );
+    _Cellular_GenericCallback_Ignore();
+    pktStatus = _Cellular_HandlePacket( &context, AT_UNSOLICITED, CELLULAR_AT_MULTI_DATA_WO_PREFIX_STRING_RESP );
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+}


### PR DESCRIPTION
- Restore URC string for generic URC callback for users to differentiate URC token.
- Add an unit-test case to test URC with colon but the token is not in the table.