### PR TITLE
HL7802: Allow to receive packets after remote disconnect the connection.

### DIFF
--- a/modules/hl7802/cellular_hl7802_api.c
+++ b/modules/hl7802/cellular_hl7802_api.c
@@ -1351,9 +1351,10 @@ CellularError_t Cellular_SocketRecv( CellularHandle_t cellularHandle,
         LogError( ( "_Cellular_RecvData: Bad input Param." ) );
         cellularStatus = CELLULAR_BAD_PARAMETER;
     }
-    else if( socketHandle->socketState != SOCKETSTATE_CONNECTED )
+    else if( ( socketHandle->socketState != SOCKETSTATE_CONNECTED ) && ( socketHandle->socketState != SOCKETSTATE_DISCONNECTED ) )
     {
         /* Check the socket connection state. */
+        /* For SOCKETSTATE_DISCONNECTED, there may be packets that can be read even though socket is disconnected by remote. */
         LogInfo( ( "Cellular_SocketRecv: socket state %d is not connected.", socketHandle->socketState ) );
 
         if( ( socketHandle->socketState == SOCKETSTATE_ALLOCATED ) || ( socketHandle->socketState == SOCKETSTATE_CONNECTING ) )
@@ -1382,7 +1383,7 @@ CellularError_t Cellular_SocketRecv( CellularHandle_t cellularHandle,
         /* Calculate the read length. */
         cellularStatus = _Cellular_GetSocketStat( cellularHandle, socketHandle, &socketStat );
 
-        if( ( cellularStatus == CELLULAR_SUCCESS ) && ( socketStat.status == TCP_SOCKET_STATE_CONNECTION_UP ) )
+        if( cellularStatus == CELLULAR_SUCCESS )
         {
             socktCmdDataLength = socketStat.rcvData;
         }


### PR DESCRIPTION
As [Receiving TCP data after connection is closed (HL7802)](https://forums.freertos.org/t/receiving-tcp-data-after-connection-is-closed-hl7802/15453) mentioned, HL7802 allows users to receive data even though socket is disconnected by remote.
This change allows HL7802 to receive packets in disconnection state.

- For BG96, device holds the close URC until receiving all packets, so we don't need to modify for this scenario.
- For SARA_R4, device doesn't allow users to receive data if socket is disconnected. 
  - It reports +CME ERROR: Operation not allowed in this scenario.