### PR TITLE
Fix type conflict in CBMC strncpy stub

### DIFF
--- a/test/cbmc/stubs/strncpy.c
+++ b/test/cbmc/stubs/strncpy.c
@@ -39,8 +39,8 @@
 #endif
 
 #if __has_builtin( __builtin___strncpy_chk )
-    void * __builtin___strncpy_chk( void * dest,
-                                    const void * src,
+    char * __builtin___strncpy_chk( char * dest,
+                                    const char * src,
                                     size_t n,
                                     size_t os )
     {
@@ -49,8 +49,8 @@
         return dest;
     }
 #else
-    void * strncpy( void * dest,
-                    const void * src,
+    char * strncpy( char * dest,
+                    const char * src,
                     size_t n )
     {
         __CPROVER_assert( __CPROVER_w_ok( dest, n ), "write" );


### PR DESCRIPTION
strncpy uses `char *` throughout, not `void *`.