### PR TITLE
CBMC proofs: address preprocessor warnings

### DIFF
--- a/test/cbmc/include/cellular_platform.h
+++ b/test/cbmc/include/cellular_platform.h
@@ -45,9 +45,13 @@
  *
  */
 
+#undef LogError
 #define LogError
+#undef LogDebug
 #define LogDebug
+#undef LogWarn
 #define LogWarn
+#undef LogInfo
 #define LogInfo
 
 #define configASSERT

--- a/test/cbmc/proofs/Cellular_CommonATCommandRaw/Cellular_CommonATCommandRaw_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonATCommandRaw/Cellular_CommonATCommandRaw_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonCleanup/Cellular_CommonCleanup_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonCleanup/Cellular_CommonCleanup_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonCreateSocket/Cellular_CommonCreateSocket_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonCreateSocket/Cellular_CommonCreateSocket_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetEidrxSettings/Cellular_CommonGetEidrxSettings_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetEidrxSettings/Cellular_CommonGetEidrxSettings_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetIPAddress/Cellular_CommonGetIPAddress_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetIPAddress/Cellular_CommonGetIPAddress_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetModemInfo/Cellular_CommonGetModemInfo_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetModemInfo/Cellular_CommonGetModemInfo_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetNetworkTime/Cellular_CommonGetNetworkTime_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetNetworkTime/Cellular_CommonGetNetworkTime_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetPsmSettings/Cellular_CommonGetPsmSettings_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetPsmSettings/Cellular_CommonGetPsmSettings_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetRegisteredNetwork/Cellular_CommonGetRegisteredNetwork_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetRegisteredNetwork/Cellular_CommonGetRegisteredNetwork_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetServiceStatus/Cellular_CommonGetServiceStatus_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetServiceStatus/Cellular_CommonGetServiceStatus_harness.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetSimCardInfo/Cellular_CommonGetSimCardInfo_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetSimCardInfo/Cellular_CommonGetSimCardInfo_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonGetSimCardLockStatus/Cellular_CommonGetSimCardLockStatus_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonGetSimCardLockStatus/Cellular_CommonGetSimCardLockStatus_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonInit/Cellular_CommonInit_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonInit/Cellular_CommonInit_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRegisterModemEventCallback/Cellular_CommonRegisterModemEventCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRegisterModemEventCallback/Cellular_CommonRegisterModemEventCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRegisterUrcGenericCallback/Cellular_CommonRegisterUrcGenericCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRegisterUrcGenericCallback/Cellular_CommonRegisterUrcGenericCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRegisterUrcNetworkRegistrationEventCallback/Cellular_CommonRegisterUrcNetworkRegistrationEventCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRegisterUrcNetworkRegistrationEventCallback/Cellular_CommonRegisterUrcNetworkRegistrationEventCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRegisterUrcPdnEventCallback/Cellular_CommonRegisterUrcPdnEventCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRegisterUrcPdnEventCallback/Cellular_CommonRegisterUrcPdnEventCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRegisterUrcSignalStrengthChangedCallback/Cellular_CommonRegisterUrcSignalStrengthChangedCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRegisterUrcSignalStrengthChangedCallback/Cellular_CommonRegisterUrcSignalStrengthChangedCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRfOff/Cellular_CommonRfOff_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRfOff/Cellular_CommonRfOff_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonRfOn/Cellular_CommonRfOn_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonRfOn/Cellular_CommonRfOn_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSetEidrxSettings/Cellular_CommonSetEidrxSettings_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSetEidrxSettings/Cellular_CommonSetEidrxSettings_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSetPdnConfig/Cellular_CommonSetPdnConfig_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSetPdnConfig/Cellular_CommonSetPdnConfig_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSetPsmSettings/Cellular_CommonSetPsmSettings_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSetPsmSettings/Cellular_CommonSetPsmSettings_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSocketRegisterClosedCallback/Cellular_CommonSocketRegisterClosedCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSocketRegisterClosedCallback/Cellular_CommonSocketRegisterClosedCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSocketRegisterDataReadyCallback/Cellular_CommonSocketRegisterDataReadyCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSocketRegisterDataReadyCallback/Cellular_CommonSocketRegisterDataReadyCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSocketRegisterSocketOpenCallback/Cellular_CommonSocketRegisterSocketOpenCallback_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSocketRegisterSocketOpenCallback/Cellular_CommonSocketRegisterSocketOpenCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonSocketSetSockOpt/Cellular_CommonSocketSetSockOpt_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonSocketSetSockOpt/Cellular_CommonSocketSetSockOpt_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonUrcProcessCereg/Cellular_CommonUrcProcessCereg_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonUrcProcessCereg/Cellular_CommonUrcProcessCereg_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonUrcProcessCgreg/Cellular_CommonUrcProcessCgreg_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonUrcProcessCgreg/Cellular_CommonUrcProcessCgreg_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/Cellular_CommonUrcProcessCreg/Cellular_CommonUrcProcessCreg_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonUrcProcessCreg/Cellular_CommonUrcProcessCreg_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_ComputeSignalBars/_Cellular_ComputeSignalBars_harness.c
+++ b/test/cbmc/proofs/_Cellular_ComputeSignalBars/_Cellular_ComputeSignalBars_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_ConvertCsqSignalBer/_Cellular_ConvertCsqSignalBer_harness.c
+++ b/test/cbmc/proofs/_Cellular_ConvertCsqSignalBer/_Cellular_ConvertCsqSignalBer_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_ConvertCsqSignalRssi/_Cellular_ConvertCsqSignalRssi_harness.c
+++ b/test/cbmc/proofs/_Cellular_ConvertCsqSignalRssi/_Cellular_ConvertCsqSignalRssi_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_GenericCallback/_Cellular_GenericCallback_harness.c
+++ b/test/cbmc/proofs/_Cellular_GenericCallback/_Cellular_GenericCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_GetCurrentRat/_Cellular_GetCurrentRat_harness.c
+++ b/test/cbmc/proofs/_Cellular_GetCurrentRat/_Cellular_GetCurrentRat_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_GetModuleContext/_Cellular_GetModuleContext_harness.c
+++ b/test/cbmc/proofs/_Cellular_GetModuleContext/_Cellular_GetModuleContext_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_GetSocketData/_Cellular_GetSocketData_harness.c
+++ b/test/cbmc/proofs/_Cellular_GetSocketData/_Cellular_GetSocketData_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_platform.h"
 #include "cellular_types.h"

--- a/test/cbmc/proofs/_Cellular_IsValidSocket/_Cellular_IsValidSocket_harness.c
+++ b/test/cbmc/proofs/_Cellular_IsValidSocket/_Cellular_IsValidSocket_harness.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_platform.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"

--- a/test/cbmc/proofs/_Cellular_LibCleanup/_Cellular_LibCleanup_harness.c
+++ b/test/cbmc/proofs/_Cellular_LibCleanup/_Cellular_LibCleanup_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_ModemEventCallback/_Cellular_ModemEventCallback_harness.c
+++ b/test/cbmc/proofs/_Cellular_ModemEventCallback/_Cellular_ModemEventCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_NetworkRegistrationCallback/_Cellular_NetworkRegistrationCallback_harness.c
+++ b/test/cbmc/proofs/_Cellular_NetworkRegistrationCallback/_Cellular_NetworkRegistrationCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_PdnEventCallback/_Cellular_PdnEventCallback_harness.c
+++ b/test/cbmc/proofs/_Cellular_PdnEventCallback/_Cellular_PdnEventCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_RemoveSocketData/_Cellular_RemoveSocketData_harness.c
+++ b/test/cbmc/proofs/_Cellular_RemoveSocketData/_Cellular_RemoveSocketData_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_SignalStrengthChangedCallback/_Cellular_SignalStrengthChangedCallback_harness.c
+++ b/test/cbmc/proofs/_Cellular_SignalStrengthChangedCallback/_Cellular_SignalStrengthChangedCallback_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"

--- a/test/cbmc/proofs/_Cellular_TranslateAtCoreStatus/_Cellular_TranslateAtCoreStatus_harness.c
+++ b/test/cbmc/proofs/_Cellular_TranslateAtCoreStatus/_Cellular_TranslateAtCoreStatus_harness.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 /* Cellular APIs includes. */
+#include "cellular_config.h"
 #include "cellular_config_defaults.h"
 #include "cellular_types.h"
 #include "cellular_common_internal.h"


### PR DESCRIPTION
See individual commit messages: we got a number of preprocessor warnings as the sequence of loading headers wasn't right.