### PR TITLE
_processUrcPacket manipulate string in function scope

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -355,7 +355,7 @@ ingroup
 inidcate
 init
 inputline
-inputwithprefix 
+inputwithprefix
 int
 interdelayms
 intf

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -355,6 +355,7 @@ ingroup
 inidcate
 init
 inputline
+inputwithprefix 
 int
 interdelayms
 intf

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -119,6 +119,9 @@ static CellularPktStatus_t _convertAndQueueRespPacket( CellularContext_t * pCont
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief copy the URC log in the buffer to a heap memory and process it.
+ */
 static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
                                               const char * pBuf )
 {
@@ -131,15 +134,16 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
     /* pBuf is checked in _Cellular_HandlePacket. */
     atStatus = Cellular_ATStrDup( &pInputLine, pBuf );
 
-    LogDebug( ( "Next URC token to parse [%s]", pInputLine ) );
-
     if( atStatus != CELLULAR_AT_SUCCESS )
     {
         /* Fail to allocate memory. */
+        LogError( ( "Failed to allocate memory for URC [%s]", pBuf ) );
         pktStatus = CELLULAR_PKT_STATUS_FAILURE;
     }
     else
     {
+        LogDebug( ( "Next URC token to parse [%s]", pInputLine ) );
+
         /* Check if prefix exist in the input string. The pInputLine is checked in Cellular_ATStrDup. */
         ( void ) Cellular_ATIsPrefixPresent( pInputLine, &inputWithPrefix );
 
@@ -172,7 +176,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
 
         if( pktStatus == CELLULAR_PKT_STATUS_PREFIX_MISMATCH )
         {
-            /* No URC callback function available, check for generic call back. */
+            /* No URC callback function available, check for generic callback. */
             LogDebug( ( "No URC Callback func avail %s, now trying generic URC Callback", pTokenPtr ) );
 
             if( inputWithPrefix == true )

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -128,10 +128,10 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
     char * pSavePtr = NULL, * pTokenPtr = NULL;
     CellularATError_t atStatus = CELLULAR_AT_SUCCESS;
 
-    LogDebug( ( "Next URC token to parse [%s]", pInputLine ) );
-
     /* pBuf is checked in _Cellular_HandlePacket. */
     atStatus = Cellular_ATStrDup( &pInputLine, pBuf );
+
+    LogDebug( ( "Next URC token to parse [%s]", pInputLine ) );
 
     if( atStatus != CELLULAR_AT_SUCCESS )
     {

--- a/test/unit-test/cellular_pkthandler_utest.c
+++ b/test/unit-test/cellular_pkthandler_utest.c
@@ -758,7 +758,7 @@ void test__Cellular_HandlePacket_Wrong_RespType( void )
     memset( &context, 0, sizeof( CellularContext_t ) );
 
     /* Send invalid message type. */
-    pktStatus = _Cellular_HandlePacket( &context, AT_UNDEFINED + 1, NULL );
+    pktStatus = _Cellular_HandlePacket( &context, AT_UNDEFINED + 1, CELLULAR_URC_TOKEN_STRING_SMALLER_INPUT );
 
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_BAD_PARAM, pktStatus );
 }


### PR DESCRIPTION
This PR is related issue #130.

* Remove the urcParseToken function. Manipulate allocated string in function scope in _processUrcPacket only.
* Use different variable name for different URC pattern to help reader understanding the handling flow.
  * **URC with prefix** : ```_atParseGetHandler( pContext, pTokenPtr, pSavePtr );```
  pInputLine will be splited into the following format
  ```pIntputLine = "+" pTokenPtr + " : " + pSavePtr```
  pTokenPtr is used to search URC handler with prefix and pSavePtr is the input parameter to the URC handler.
  * **URC without prefix** : ```_atParseGetHandler( pContext, pInputLine, pInputLine );```
  pInputLine will be used to search URC handler and pInputLine will also be used as input parameter to the URC handler.
  * **URC handler not found** : ```_Cellular_GenericCallback( pContext, pInputLine );```
  CellularUrcGenericCallback_t will be called. pInputLine is the input parameter to the function.