### PR TITLE
Adding _Cellular_RegisterInputBufferCallback in common layer

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -39,12 +39,12 @@
     </tr>
     <tr>
         <td>cellular_pktio.c</td>
-        <td><center>2.2K</center></td>
+        <td><center>2.1K</center></td>
         <td><center>1.9K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>15.0K</center></b></td>
+        <td><b><center>14.9K</center></b></td>
         <td><b><center>13.6K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -30,7 +30,7 @@
     <tr>
         <td>cellular_common.c</td>
         <td><center>1.7K</center></td>
-        <td><center>1.5K</center></td>
+        <td><center>1.6K</center></td>
     </tr>
     <tr>
         <td>cellular_pkthandler.c</td>
@@ -39,12 +39,12 @@
     </tr>
     <tr>
         <td>cellular_pktio.c</td>
-        <td><center>2.0K</center></td>
-        <td><center>1.8K</center></td>
+        <td><center>2.2K</center></td>
+        <td><center>1.9K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>14.8K</center></b></td>
-        <td><b><center>13.4K</center></b></td>
+        <td><b><center>15.0K</center></b></td>
+        <td><b><center>13.6K</center></b></td>
     </tr>
 </table>

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -269,6 +269,7 @@ efhplmnwact
 eidrxlist
 eidrxsettingslist
 emerg
+endcode
 endcond
 endif
 endpatternlen
@@ -377,6 +378,7 @@ isurc
 isvalidpdn
 isvalidsocket
 jan
+keepprocess
 keylist
 keylistlen
 kselacq
@@ -409,6 +411,7 @@ mcc
 md
 mem
 memorystatus
+memset
 metadata
 min
 misra
@@ -656,6 +659,7 @@ pstr
 pstring
 pstrvalue
 ptemp
+ptempline
 ptempstring
 ptestusrdata
 ptofree

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -669,8 +669,6 @@ ptokentable
 ptr
 puk
 pundefinedrespcbcontext
-purcdatacallbackcontext
-purcdatalength
 puserdata
 pvportmalloc
 pwr
@@ -865,7 +863,6 @@ unneccessary
 upperthreshold
 urat
 urc
-urcdatacallback
 urcevent
 urcprocesscgev
 urcprocessciev

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -665,6 +665,8 @@ ptokentable
 ptr
 puk
 pundefinedrespcbcontext
+purcdatacallbackcontext
+purcdatalength
 puserdata
 pvportmalloc
 pwr
@@ -859,6 +861,7 @@ unneccessary
 upperthreshold
 urat
 urc
+urcdatacallback
 urcevent
 urcprocesscgev
 urcprocessciev

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -355,7 +355,7 @@ inet
 ingroup
 inidcate
 init
-inputbuffercallback 
+inputbuffercallback
 inputline
 inputwithprefix
 int
@@ -488,7 +488,7 @@ pbandcfg
 pbervalue
 pbuf
 pbuffer
-pbufferlengthhandled 
+pbufferlengthhandled
 pbytesread
 pc
 pcallbackcontext
@@ -539,7 +539,7 @@ pgenericcallbackcontext
 ph
 phexdata
 pinputbuf
-pinputbuffercallbackcontext 
+pinputbuffercallbackcontext
 pinputline
 pinputptr
 pinputstr

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -355,6 +355,7 @@ inet
 ingroup
 inidcate
 init
+inputbuffercallback 
 inputline
 inputwithprefix
 int
@@ -487,6 +488,7 @@ pbandcfg
 pbervalue
 pbuf
 pbuffer
+pbufferlengthhandled 
 pbytesread
 pc
 pcallbackcontext
@@ -537,6 +539,7 @@ pgenericcallbackcontext
 ph
 phexdata
 pinputbuf
+pinputbuffercallbackcontext 
 pinputline
 pinputptr
 pinputstr

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -1138,9 +1138,9 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
 
 /*-----------------------------------------------------------*/
 
-CellularError_t _Cellular_RegisterUrcDataCallback( CellularContext_t * pContext,
-                                                   CellularUrcDataCallback_t urcDataCallback,
-                                                   void * pUrcDataCallbackContext )
+CellularError_t _Cellular_RegisterInputBufferCallback( CellularContext_t * pContext,
+                                                       CellularInputBufferCallback_t inputBufferCallback,
+                                                       void * pInputBufferCallbackContext )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
 
@@ -1151,17 +1151,17 @@ CellularError_t _Cellular_RegisterUrcDataCallback( CellularContext_t * pContext,
     }
     else
     {
-        /* urcDataCallback can be set to NULL to unregister the callback. */
+        /* inputBufferCallback can be set to NULL to unregister the callback. */
         PlatformMutex_Lock( &pContext->PktRespMutex );
-        pContext->urcDataCallback = urcDataCallback;
+        pContext->inputBufferCallback = inputBufferCallback;
 
-        if( pContext->urcDataCallback != NULL )
+        if( pContext->inputBufferCallback != NULL )
         {
-            pContext->pUrcDataCallbackContext = pUrcDataCallbackContext;
+            pContext->pInputBufferCallbackContext = pInputBufferCallbackContext;
         }
         else
         {
-            pContext->pUrcDataCallbackContext = NULL;
+            pContext->pInputBufferCallbackContext = NULL;
         }
 
         PlatformMutex_Unlock( &pContext->PktRespMutex );

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -1137,3 +1137,37 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
 }
 
 /*-----------------------------------------------------------*/
+
+CellularError_t _Cellular_RegisterUrcDataCallback( CellularContext_t * pContext,
+                                                   CellularUrcDataCallback_t urcDataCallback,
+                                                   void * pUrcDataCallbackContext )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+
+    if( pContext == NULL )
+    {
+        LogError( ( "_Cellular_RegisterUrcDataCallback: invalid context." ) );
+        cellularStatus = CELLULAR_INVALID_HANDLE;
+    }
+    else
+    {
+        /* urcDataCallback can be set to NULL to unregister the callback. */
+        PlatformMutex_Lock( &pContext->PktRespMutex );
+        pContext->urcDataCallback = urcDataCallback;
+
+        if( pContext->urcDataCallback != NULL )
+        {
+            pContext->pUrcDataCallbackContext = pUrcDataCallbackContext;
+        }
+        else
+        {
+            pContext->pUrcDataCallbackContext = NULL;
+        }
+
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -648,40 +648,28 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
 
     if( bytesDataAndLeft >= pContext->dataLength )
     {
-        /* There is no command waiting for response if pAtResp is NULL. The is the
-         * case that URC data is received from the buffer. */
-        if( pAtResp != NULL )
-        {
-            /* Add data to the response linked list. */
-            _saveRawData( pStartOfData, pAtResp, pContext->dataLength );
+        /* Add data to the response linked list. */
+        _saveRawData( pStartOfData, pAtResp, pContext->dataLength );
 
-            /* Advance pLine to a point after data. */
-            *ppLine = &pStartOfData[ pContext->dataLength ];
+        /* Advance pLine to a point after data. */
+        *ppLine = &pStartOfData[ pContext->dataLength ];
 
-            /* There are more bytes after the data. */
-            *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
+        /* There are more bytes after the data. */
+        *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
 
-            LogDebug( ( "_handleData : read buffer buffer %p start %p prefix %d left %d, read total %d",
-                        pContext->pktioReadBuf,
-                        pStartOfData,
-                        bytesBeforeData,
-                        *pBytesLeft,
-                        bytesRead ) );
+        LogDebug( ( "_handleData : read buffer buffer %p start %p prefix %d left %d, read total %d",
+                    pContext->pktioReadBuf,
+                    pStartOfData,
+                    bytesBeforeData,
+                    *pBytesLeft,
+                    bytesRead ) );
 
-            /* reset the data related variables. */
-            pContext->dataLength = 0U;
+        /* reset the data related variables. */
+        pContext->dataLength = 0U;
 
-            /* Set the pPktioReadPtr to indicate data already handled. */
-            pContext->pPktioReadPtr = *ppLine;
-            pContext->partialDataRcvdLen = *pBytesLeft;
-        }
-        else
-        {
-            /* This the the URC data receive case. The data required by URC data callback
-             * is received. Leave the data mode by setting dataLength to 0. */
-            *pBytesLeft = bytesRead;
-            pContext->dataLength = 0U;
-        }
+        /* Set the pPktioReadPtr to indicate data already handled. */
+        pContext->pPktioReadPtr = *ppLine;
+        pContext->partialDataRcvdLen = *pBytesLeft;
     }
     else
     {

--- a/source/include/common/cellular_common.h
+++ b/source/include/common/cellular_common.h
@@ -225,22 +225,22 @@ typedef CellularPktStatus_t ( * CellularUndefinedRespCallback_t )( void * pCallb
 
 /**
  * @ingroup cellular_common_datatypes_functionpointers
- * @brief Callback used to process URC data buffer.
+ * @brief Callback used to process input buffer.
  *
- * @param[in] pUrcDataCallbackContext The pCallbackContext in _Cellular_TimeoutAtcmdDataRecvRequestWithCallback.
+ * @param[in] pInputBufferCallbackContext The pCallbackContext in CellularInputBufferCallback_t.
  * @param[in] pBuffer The data buffer with modem response data.
  * @param[in] bufferLength The length of the input buffer.
- * @param[out] pUrcDataLength The length of the URC data in the buffer.
+ * @param[out] pBufferLengthHandled The length of the handled input buffer in pBuffer.
  *
  * @return CELLULAR_PKT_STATUS_OK if the operation is successful.
  * CELLULAR_PKT_STATUS_SIZE_MISMATCH if more data is required.
- * CELLULAR_PKT_STATUS_PREFIX_MISMATCH if this is not a URC data buffer
+ * CELLULAR_PKT_STATUS_PREFIX_MISMATCH if the input buffer is not handled in the callback.
  * Otherwise an error code indicating the cause of the error.
  */
-typedef CellularPktStatus_t ( * CellularUrcDataCallback_t ) ( void * pUrcDataCallbackContext,
-                                                              char * pBuffer,
-                                                              uint32_t bufferLength,
-                                                              uint32_t * pUrcDataLength );
+typedef CellularPktStatus_t ( * CellularInputBufferCallback_t ) ( void * pInputBufferCallbackContext,
+                                                                  char * pBuffer,
+                                                                  uint32_t bufferLength,
+                                                                  uint32_t * pBufferLengthHandled );
 
 /*-----------------------------------------------------------*/
 
@@ -643,22 +643,22 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
                                                          void * pCallbackContext );
 
 /**
- * @brief Register URC data callback.
+ * @brief Register input buffer callback.
  *
- * Cellular module can register the callback function to handle URC data from input
- * buffer.
+ * Cellular module can register the callback function to handler the input buffer
+ * before pktio continue to process the line in the buffer.
  *
  * @param[in] pContext The opaque cellular context pointer created by Cellular_Init.
- * @param[in] urcDataCallback The callback function to handle the URC data.
- * @param[in] pUrcDataCallbackContext The pUrcDataCallbackContext passed to the urcDataCallback
- * callback function if urcDataCallback is not NULL.
+ * @param[in] inputBufferCallback The callback function to handle the URC data.
+ * @param[in] pInputBufferCallbackContext The pInputBufferCallbackContext passed to the inputBufferCallback
+ * callback function if inputBufferCallback is not NULL.
  *
  * @return CELLULAR_SUCCESS if the operation is successful, otherwise an error code
  * indicating the cause of the error.
  */
-CellularError_t _Cellular_RegisterUrcDataCallback( CellularContext_t * pContext,
-                                                   CellularUrcDataCallback_t urcDataCallback,
-                                                   void * pUrcDataCallbackContext );
+CellularError_t _Cellular_RegisterInputBufferCallback( CellularContext_t * pContext,
+                                                       CellularInputBufferCallback_t inputBufferCallback,
+                                                       void * pInputBufferCallbackContext );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/common/cellular_common.h
+++ b/source/include/common/cellular_common.h
@@ -223,6 +223,25 @@ typedef CellularPktStatus_t ( * CellularATCommandDataSendPrefixCallback_t ) ( vo
 typedef CellularPktStatus_t ( * CellularUndefinedRespCallback_t )( void * pCallbackContext,
                                                                    const char * pLine );
 
+/**
+ * @ingroup cellular_common_datatypes_functionpointers
+ * @brief Callback used to process URC data buffer.
+ *
+ * @param[in] pUrcDataCallbackContext The pCallbackContext in _Cellular_TimeoutAtcmdDataRecvRequestWithCallback.
+ * @param[in] pBuffer The data buffer with modem response data.
+ * @param[in] bufferLength The length of the input buffer.
+ * @param[out] pUrcDataLength The length of the URC data in the buffer.
+ *
+ * @return CELLULAR_PKT_STATUS_OK if the operation is successful.
+ * CELLULAR_PKT_STATUS_SIZE_MISMATCH if more data is required.
+ * CELLULAR_PKT_STATUS_PREFIX_MISMATCH if this is not a URC data buffer
+ * Otherwise an error code indicating the cause of the error.
+ */
+typedef CellularPktStatus_t ( * CellularUrcDataCallback_t ) ( void * pUrcDataCallbackContext,
+                                                              char * pBuffer,
+                                                              uint32_t bufferLength,
+                                                              uint32_t * pUrcDataLength );
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -622,6 +641,24 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataSendSuccessToken( CellularContext_
 CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pContext,
                                                          CellularUndefinedRespCallback_t undefinedRespCallback,
                                                          void * pCallbackContext );
+
+/**
+ * @brief Register URC data callback.
+ *
+ * Cellular module can register the callback function to handle URC data from input
+ * buffer.
+ *
+ * @param[in] pContext The opaque cellular context pointer created by Cellular_Init.
+ * @param[in] urcDataCallback The callback function to handle the URC data.
+ * @param[in] pUrcDataCallbackContext The pUrcDataCallbackContext passed to the urcDataCallback
+ * callback function if urcDataCallback is not NULL.
+ *
+ * @return CELLULAR_SUCCESS if the operation is successful, otherwise an error code
+ * indicating the cause of the error.
+ */
+CellularError_t _Cellular_RegisterUrcDataCallback( CellularContext_t * pContext,
+                                                   CellularUrcDataCallback_t urcDataCallback,
+                                                   void * pUrcDataCallbackContext );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/private/cellular_common_internal.h
+++ b/source/include/private/cellular_common_internal.h
@@ -144,8 +144,8 @@ struct CellularContext
     _atRespType_t recvdMsgType;                                        /**<  The received AT response type. */
     CellularUndefinedRespCallback_t undefinedRespCallback;             /**<  Undefined response callback function. */
     void * pUndefinedRespCBContext;                                    /**<  The pCallbackContext passed to CellularUndefinedRespCallback_t. */
-    CellularUrcDataCallback_t urcDataCallback;                         /**<  URC data preprocess callback function. */
-    void * pUrcDataCallbackContext;                                    /**<  the callback context passed to urcDataCallback. */
+    CellularInputBufferCallback_t inputBufferCallback;                 /**<  URC data preprocess callback function. */
+    void * pInputBufferCallbackContext;                                /**<  the callback context passed to urcDataCallback. */
 
     /* PktIo data handling. */
     uint32_t dataLength;                                              /**<  The data length in pLine. */

--- a/source/include/private/cellular_common_internal.h
+++ b/source/include/private/cellular_common_internal.h
@@ -145,7 +145,7 @@ struct CellularContext
     CellularUndefinedRespCallback_t undefinedRespCallback;             /**<  Undefined response callback function. */
     void * pUndefinedRespCBContext;                                    /**<  The pCallbackContext passed to CellularUndefinedRespCallback_t. */
     CellularInputBufferCallback_t inputBufferCallback;                 /**<  URC data preprocess callback function. */
-    void * pInputBufferCallbackContext;                                /**<  the callback context passed to urcDataCallback. */
+    void * pInputBufferCallbackContext;                                /**<  the callback context passed to inputBufferCallback. */
 
     /* PktIo data handling. */
     uint32_t dataLength;                                              /**<  The data length in pLine. */

--- a/source/include/private/cellular_common_internal.h
+++ b/source/include/private/cellular_common_internal.h
@@ -144,6 +144,8 @@ struct CellularContext
     _atRespType_t recvdMsgType;                                        /**<  The received AT response type. */
     CellularUndefinedRespCallback_t undefinedRespCallback;             /**<  Undefined response callback function. */
     void * pUndefinedRespCBContext;                                    /**<  The pCallbackContext passed to CellularUndefinedRespCallback_t. */
+    CellularUrcDataCallback_t urcDataCallback;                         /**<  URC data preprocess callback function. */
+    void * pUrcDataCallbackContext;                                    /**<  the callback context passed to urcDataCallback. */
 
     /* PktIo data handling. */
     uint32_t dataLength;                                              /**<  The data length in pLine. */

--- a/test/unit-test/cellular_common_utest.c
+++ b/test/unit-test/cellular_common_utest.c
@@ -410,6 +410,20 @@ void MockPlatformMutex_Destroy( PlatformMutex_t * pMutex )
     pMutex->created = false;
 }
 
+
+static CellularPktStatus_t prvDummyInputBufferCallback( void * pInputBufferCallbackContext,
+                                                        char * pBuffer,
+                                                        uint32_t bufferLength,
+                                                        uint32_t * pBufferLengthHandled )
+{
+    ( void ) pInputBufferCallbackContext;
+    ( void ) pBuffer;
+    ( void ) bufferLength;
+    ( void ) pBufferLengthHandled;
+
+    return CELLULAR_PKT_STATUS_OK;
+}
+
 /* ========================================================================== */
 
 /**
@@ -1642,77 +1656,64 @@ void test__Cellular_RegisterUndefinedRespCallback_Happy_Path( void )
 }
 
 /**
- * @brief _Cellular_RegisterUrcDataCallback - parameter null context.
+ * @brief _Cellular_RegisterInputBufferCallback - parameter null context.
  * pContext parameter is NULL. Verify the return value.
  */
-void test__Cellular_RegisterUrcDataCallback_Null_Context( void )
+void test__Cellular_RegisterInputBufferCallback_Null_Context( void )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
 
     /* API call. */
-    cellularStatus = _Cellular_RegisterUrcDataCallback( NULL, NULL, NULL );
+    cellularStatus = _Cellular_RegisterInputBufferCallback( NULL, NULL, NULL );
 
     /* Validation. */
     TEST_ASSERT_EQUAL( CELLULAR_INVALID_HANDLE, cellularStatus );
 }
 
-CellularPktStatus_t prvDummyUrcDataCallback( void * pUrcDataCallbackContext,
-                                             char * pBuffer,
-                                             uint32_t bufferLength,
-                                             uint32_t * pUrcDataLength )
-{
-    ( void ) pUrcDataCallbackContext;
-    ( void ) pBuffer;
-    ( void ) bufferLength;
-    ( void ) pUrcDataLength;
-
-    return CELLULAR_PKT_STATUS_OK;
-}
-
 /**
- * @brief _Cellular_RegisterUrcDataCallback - parameter NULL callback.
- * urcDataCallback parameter is NULL. Verify the member variable is updated.
+ * @brief _Cellular_RegisterInputBufferCallback - parameter NULL callback.
+ * inputBufferCallback parameter is NULL. Verify the member variable is updated.
  */
-void test__Cellular_RegisterUrcDataCallback_Null_Callback( void )
+void test__Cellular_RegisterInputBufferCallback_Null_Callback( void )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
     CellularContext_t cellularContext;
-    uint32_t urcDataCallbackContext;
+    uint32_t inputBufferCallbackContext;
 
     /* Setup internal variable. */
     memset( &cellularContext, 0, sizeof( CellularContext_t ) );
-    cellularContext.urcDataCallback = prvDummyUrcDataCallback;
-    cellularContext.pUrcDataCallbackContext = &urcDataCallbackContext;
+    cellularContext.inputBufferCallback = prvDummyInputBufferCallback;
+    cellularContext.pInputBufferCallbackContext = &inputBufferCallbackContext;
 
     /* API call. */
-    cellularStatus = _Cellular_RegisterUrcDataCallback( &cellularContext, NULL, &urcDataCallbackContext );
+    cellularStatus = _Cellular_RegisterInputBufferCallback( &cellularContext, NULL, &inputBufferCallbackContext );
 
     /* Validation. */
     TEST_ASSERT_EQUAL( CELLULAR_SUCCESS, cellularStatus );
-    TEST_ASSERT_EQUAL( NULL, cellularContext.urcDataCallback );
-    /* The callback context will be cleaned when urcDataCallback is NULL. */
-    TEST_ASSERT_EQUAL( NULL, cellularContext.pUrcDataCallbackContext );
+    TEST_ASSERT_EQUAL( NULL, cellularContext.inputBufferCallback );
+    /* The callback context will be cleaned when inputBufferCallback is NULL. */
+    TEST_ASSERT_EQUAL( NULL, cellularContext.pInputBufferCallbackContext );
 }
 
 /**
- * @brief _Cellular_RegisterUrcDataCallback - Setup the URC data callback.
+ * @brief _Cellular_RegisterInputBufferCallback - Setup the URC data callback.
  * Verify the URC data callback and callback context are set correctly.
  */
-void test__Cellular_RegisterUrcDataCallback_Happy_Path( void )
+void test__Cellular_RegisterInputBufferCallback_Happy_Path( void )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
     CellularContext_t cellularContext;
-    uint32_t urcDataCallbackContext;
+    uint32_t inputBufferCallbackContext;
 
     /* Setup internal variable. */
     memset( &cellularContext, 0, sizeof( CellularContext_t ) );
-    cellularContext.urcDataCallback = NULL;
+    cellularContext.inputBufferCallback = NULL;
 
     /* API call. */
-    cellularStatus = _Cellular_RegisterUrcDataCallback( &cellularContext, prvDummyUrcDataCallback, &urcDataCallbackContext );
+    cellularStatus = _Cellular_RegisterInputBufferCallback( &cellularContext, prvDummyInputBufferCallback, &inputBufferCallbackContext );
 
     /* Validation. */
     TEST_ASSERT_EQUAL( CELLULAR_SUCCESS, cellularStatus );
-    TEST_ASSERT_EQUAL( prvDummyUrcDataCallback, cellularContext.urcDataCallback );
-    TEST_ASSERT_EQUAL( &urcDataCallbackContext, cellularContext.pUrcDataCallbackContext );
+    TEST_ASSERT_EQUAL( prvDummyInputBufferCallback, cellularContext.inputBufferCallback );
+    TEST_ASSERT_EQUAL( &inputBufferCallbackContext, cellularContext.pInputBufferCallbackContext );
 }

--- a/test/unit-test/cellular_common_utest.c
+++ b/test/unit-test/cellular_common_utest.c
@@ -1656,10 +1656,10 @@ void test__Cellular_RegisterUrcDataCallback_Null_Context( void )
     TEST_ASSERT_EQUAL( CELLULAR_INVALID_HANDLE, cellularStatus );
 }
 
-CellularPktStatus_t prvDummyUrcDataCallback ( void * pUrcDataCallbackContext,
-                                              char * pBuffer,
-                                              uint32_t bufferLength,
-                                              uint32_t * pUrcDataLength )
+CellularPktStatus_t prvDummyUrcDataCallback( void * pUrcDataCallbackContext,
+                                             char * pBuffer,
+                                             uint32_t bufferLength,
+                                             uint32_t * pUrcDataLength )
 {
     ( void ) pUrcDataCallbackContext;
     ( void ) pBuffer;

--- a/test/unit-test/cellular_common_utest.c
+++ b/test/unit-test/cellular_common_utest.c
@@ -1640,3 +1640,77 @@ void test__Cellular_RegisterUndefinedRespCallback_Happy_Path( void )
     TEST_ASSERT_NULL( context.undefinedRespCallback );
     TEST_ASSERT_NULL( context.pUndefinedRespCBContext );
 }
+
+/**
+ * @brief _Cellular_RegisterUrcDataCallback - parameter null context.
+ * pContext parameter is NULL. Verify the return value.
+ */
+void test__Cellular_RegisterUrcDataCallback_Null_Context( void )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+
+    /* API call. */
+    cellularStatus = _Cellular_RegisterUrcDataCallback( NULL, NULL, NULL );
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( CELLULAR_INVALID_HANDLE, cellularStatus );
+}
+
+CellularPktStatus_t prvDummyUrcDataCallback ( void * pUrcDataCallbackContext,
+                                              char * pBuffer,
+                                              uint32_t bufferLength,
+                                              uint32_t * pUrcDataLength )
+{
+    ( void ) pUrcDataCallbackContext;
+    ( void ) pBuffer;
+    ( void ) bufferLength;
+    ( void ) pUrcDataLength;
+
+    return CELLULAR_PKT_STATUS_OK;
+}
+
+/**
+ * @brief _Cellular_RegisterUrcDataCallback - parameter NULL callback.
+ * urcDataCallback parameter is NULL. Verify the member variable is updated.
+ */
+void test__Cellular_RegisterUrcDataCallback_Null_Callback( void )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularContext_t cellularContext;
+    uint32_t urcDataCallbackContext;
+
+    /* Setup internal variable. */
+    memset( &cellularContext, 0, sizeof( CellularContext_t ) );
+    cellularContext.urcDataCallback = prvDummyUrcDataCallback;
+    cellularContext.pUrcDataCallbackContext = &urcDataCallbackContext;
+
+    /* API call. */
+    cellularStatus = _Cellular_RegisterUrcDataCallback( &cellularContext, NULL, &urcDataCallbackContext );
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( NULL, cellularContext.urcDataCallback );
+    /* The callback context will be cleaned when urcDataCallback is NULL. */
+    TEST_ASSERT_EQUAL( NULL, cellularContext.pUrcDataCallbackContext );
+}
+
+/**
+ * @brief _Cellular_RegisterUrcDataCallback - Setup the URC data callback.
+ * Verify the URC data callback and callback context are set correctly.
+ */
+void test__Cellular_RegisterUrcDataCallback_Happy_Path( void )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularContext_t cellularContext;
+    uint32_t urcDataCallbackContext;
+
+    /* Setup internal variable. */
+    memset( &cellularContext, 0, sizeof( CellularContext_t ) );
+    cellularContext.urcDataCallback = NULL;
+
+    /* API call. */
+    cellularStatus = _Cellular_RegisterUrcDataCallback( &cellularContext, prvDummyUrcDataCallback, &urcDataCallbackContext );
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( prvDummyUrcDataCallback, cellularContext.urcDataCallback );
+    TEST_ASSERT_EQUAL( &urcDataCallbackContext, cellularContext.pUrcDataCallbackContext );
+}

--- a/test/unit-test/cellular_common_utest.c
+++ b/test/unit-test/cellular_common_utest.c
@@ -1688,6 +1688,7 @@ void test__Cellular_RegisterUrcDataCallback_Null_Callback( void )
     cellularStatus = _Cellular_RegisterUrcDataCallback( &cellularContext, NULL, &urcDataCallbackContext );
 
     /* Validation. */
+    TEST_ASSERT_EQUAL( CELLULAR_SUCCESS, cellularStatus );
     TEST_ASSERT_EQUAL( NULL, cellularContext.urcDataCallback );
     /* The callback context will be cleaned when urcDataCallback is NULL. */
     TEST_ASSERT_EQUAL( NULL, cellularContext.pUrcDataCallbackContext );
@@ -1711,6 +1712,7 @@ void test__Cellular_RegisterUrcDataCallback_Happy_Path( void )
     cellularStatus = _Cellular_RegisterUrcDataCallback( &cellularContext, prvDummyUrcDataCallback, &urcDataCallbackContext );
 
     /* Validation. */
+    TEST_ASSERT_EQUAL( CELLULAR_SUCCESS, cellularStatus );
     TEST_ASSERT_EQUAL( prvDummyUrcDataCallback, cellularContext.urcDataCallback );
     TEST_ASSERT_EQUAL( &urcDataCallbackContext, cellularContext.pUrcDataCallbackContext );
 }

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -79,18 +79,18 @@
 #define MAX_QIRD_STRING_PREFIX_STRING                        ( 14U )           /* The max data prefix string is "+QIRD: 1460\r\n" */
 
 /* URC data callback test string. */
-#define URC_DATA_CALLBACK_PREFIX_MISMATCH_STR           "+URC_PREFIX_MISMATCH:\r\n"
-#define URC_DATA_CALLBACK_OTHER_ERROR_STR               "+URC_OTHER_ERROR:\r\n"
-#define URC_DATA_CALLBACK_INCORRECT_BUFFER_LEN_STR      "+URC_INCORRECT_LENGTH:\r\n"
-#define URC_DATA_CALLBACK_MATCH_STR                     "+URC_DATA:123\r\n"
-#define URC_DATA_CALLBACK_MATCH_STR_LENGTH              15
-#define URC_DATA_CALLBACK_LEFT_OVER_STR                 "+URC_STRING:123\r\n"
+#define URC_DATA_CALLBACK_PREFIX_MISMATCH_STR                "+URC_PREFIX_MISMATCH:\r\n"
+#define URC_DATA_CALLBACK_OTHER_ERROR_STR                    "+URC_OTHER_ERROR:\r\n"
+#define URC_DATA_CALLBACK_INCORRECT_BUFFER_LEN_STR           "+URC_INCORRECT_LENGTH:\r\n"
+#define URC_DATA_CALLBACK_MATCH_STR                          "+URC_DATA:123\r\n"
+#define URC_DATA_CALLBACK_MATCH_STR_LENGTH                   15
+#define URC_DATA_CALLBACK_LEFT_OVER_STR                      "+URC_STRING:123\r\n"
 
-#define URC_DATA_CALLBACK_MATCH_STR_PREFIX              "+URC_PART_DATA:"
-#define URC_DATA_CALLBACK_MATCH_STR_PREFIX_LENGTH       15
-#define URC_DATA_CALLBACK_MATCH_STR_PART1               URC_DATA_CALLBACK_MATCH_STR_PREFIX"14\r\n1234"
-#define URC_DATA_CALLBACK_MATCH_STR_PART2               "1234567890\r\n"
-#define URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH         35
+#define URC_DATA_CALLBACK_MATCH_STR_PREFIX                   "+URC_PART_DATA:"
+#define URC_DATA_CALLBACK_MATCH_STR_PREFIX_LENGTH            15
+#define URC_DATA_CALLBACK_MATCH_STR_PART1                    URC_DATA_CALLBACK_MATCH_STR_PREFIX "14\r\n1234"
+#define URC_DATA_CALLBACK_MATCH_STR_PART2                    "1234567890\r\n"
+#define URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH              35
 
 struct _cellularCommContext
 {
@@ -634,6 +634,7 @@ static CellularCommInterfaceError_t prvCommIntfReceiveCustomString( CellularComm
 
         ( void ) strncpy( ( char * ) pBuffer, pCommIntfRecvCustomString, bufferLength );
         *pDataReceivedLength = strlen( pCommIntfRecvCustomString );
+
         if( pCommIntfRecvCustomStringCallback != NULL )
         {
             pCommIntfRecvCustomStringCallback();
@@ -1590,7 +1591,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_success( v
     recvCount = 1;
     atCmdType = CELLULAR_AT_NO_RESULT;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
-    pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR""URC_DATA_CALLBACK_LEFT_OVER_STR;
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR ""URC_DATA_CALLBACK_LEFT_OVER_STR;
     pUrcDataPkthandlerString = URC_DATA_CALLBACK_LEFT_OVER_STR;
     dataUrcPktHandlerCallbackIsCalled = 0;
 

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -78,6 +78,20 @@
 
 #define MAX_QIRD_STRING_PREFIX_STRING                        ( 14U )           /* The max data prefix string is "+QIRD: 1460\r\n" */
 
+/* URC data callback test string. */
+#define URC_DATA_CALLBACK_PREFIX_MISMATCH_STR           "+URC_PREFIX_MISMATCH:\r\n"
+#define URC_DATA_CALLBACK_OTHER_ERROR_STR               "+URC_OTHER_ERROR:\r\n"
+#define URC_DATA_CALLBACK_INCORRECT_BUFFER_LEN_STR      "+URC_INCORRECT_LENGTH:\r\n"
+#define URC_DATA_CALLBACK_MATCH_STR                     "+URC_DATA:123\r\n"
+#define URC_DATA_CALLBACK_MATCH_STR_LENGTH              15
+#define URC_DATA_CALLBACK_LEFT_OVER_STR                 "+URC_STRING:123\r\n"
+
+#define URC_DATA_CALLBACK_MATCH_STR_PREFIX              "+URC_PART_DATA:"
+#define URC_DATA_CALLBACK_MATCH_STR_PREFIX_LENGTH       15
+#define URC_DATA_CALLBACK_MATCH_STR_PART1               URC_DATA_CALLBACK_MATCH_STR_PREFIX"14\r\n1234"
+#define URC_DATA_CALLBACK_MATCH_STR_PART2               "1234567890\r\n"
+#define URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH         35
+
 struct _cellularCommContext
 {
     int test1;
@@ -123,8 +137,14 @@ static int32_t customCallbackContext = 0;
 
 static commIfRecvType_t testCommIfRecvType = COMM_IF_RECV_NORMAL;
 static char * pCommIntfRecvCustomString = NULL;
+static void ( * pCommIntfRecvCustomStringCallback )( void ) = NULL;
 
 static bool atCmdStatusUndefindTest = false;
+
+static void * urcDataCallbackContext = NULL;
+
+static int dataUrcPktHandlerCallbackIsCalled = 0;
+static char * pUrcDataPkthandlerString;
 
 /* Try to Keep this map in Alphabetical order. */
 /* FreeRTOS Cellular Common Library porting interface. */
@@ -224,6 +244,7 @@ void setUp()
 
     testCommIfRecvType = COMM_IF_RECV_NORMAL;
     pCommIntfRecvCustomString = NULL;
+    pCommIntfRecvCustomStringCallback = NULL;
 }
 
 /* Called after each test method. */
@@ -613,6 +634,10 @@ static CellularCommInterfaceError_t prvCommIntfReceiveCustomString( CellularComm
 
         ( void ) strncpy( ( char * ) pBuffer, pCommIntfRecvCustomString, bufferLength );
         *pDataReceivedLength = strlen( pCommIntfRecvCustomString );
+        if( pCommIntfRecvCustomStringCallback != NULL )
+        {
+            pCommIntfRecvCustomStringCallback();
+        }
     }
     else
     {
@@ -874,6 +899,78 @@ CellularPktStatus_t undefinedRespCallback( void * pCallbackContext,
 
     return undefineReturnStatus;
 }
+
+static CellularPktStatus_t cellularUrcDataCallback( void * pUrcDataCallbackContext,
+                                                    char * pBuffer,
+                                                    uint32_t bufferLength,
+                                                    uint32_t * pUrcDataLength )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+
+    /* Verify the callback context. */
+    TEST_ASSERT_EQUAL( urcDataCallbackContext, pUrcDataCallbackContext );
+
+    /* Verify the callback context. */
+    if( strncmp( pBuffer, URC_DATA_CALLBACK_PREFIX_MISMATCH_STR, bufferLength ) == 0 )
+    {
+        *pUrcDataLength = 0;
+        pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
+    }
+    else if( strncmp( pBuffer, URC_DATA_CALLBACK_OTHER_ERROR_STR, bufferLength ) == 0 )
+    {
+        *pUrcDataLength = 0;
+        pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+    }
+    else if( strncmp( pBuffer, URC_DATA_CALLBACK_INCORRECT_BUFFER_LEN_STR, bufferLength ) == 0 )
+    {
+        /* Return incorrect buffer length. */
+        *pUrcDataLength = bufferLength + 1;
+        pktStatus = CELLULAR_PKT_STATUS_OK;
+    }
+    else if( strncmp( pBuffer, URC_DATA_CALLBACK_MATCH_STR, URC_DATA_CALLBACK_MATCH_STR_LENGTH ) == 0 )
+    {
+        *pUrcDataLength = 15;
+        pktStatus = CELLULAR_PKT_STATUS_OK;
+    }
+    else if( strncmp( pBuffer, URC_DATA_CALLBACK_MATCH_STR_PREFIX, URC_DATA_CALLBACK_MATCH_STR_PREFIX_LENGTH ) == 0 )
+    {
+        if( bufferLength < URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH )
+        {
+            pktStatus = CELLULAR_PKT_STATUS_SIZE_MISMATCH;
+        }
+        else if( bufferLength == URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH )
+        {
+            *pUrcDataLength = URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH;
+            pktStatus = CELLULAR_PKT_STATUS_OK;
+        }
+    }
+
+    return pktStatus;
+}
+
+static CellularPktStatus_t prvDataUrcPktHandlerCallback( CellularContext_t * pContext,
+                                                         _atRespType_t atRespType,
+                                                         const void * pBuffer )
+{
+    int compareResult;
+
+    dataUrcPktHandlerCallbackIsCalled = 1;
+
+    /* Verify the atRespType is AT_UNSOLICITED. */
+    TEST_ASSERT_EQUAL( AT_UNSOLICITED, atRespType );
+
+    /* Verify the pBuffer contains the same string in pCommIntfRecvCustomString. */
+    compareResult = strncmp( pBuffer, pUrcDataPkthandlerString, strlen( pBuffer ) );
+    TEST_ASSERT_EQUAL( 0, compareResult );
+
+    return CELLULAR_PKT_STATUS_OK;
+}
+
+static void prvUrcDataCommIntfRecvCallback( void )
+{
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR_PART2;
+}
+
 
 /* ========================================================================== */
 
@@ -1278,6 +1375,291 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_pktDataPrefixCB__Test( void )
     pktStatus = _Cellular_PktioInit( &context, PktioHandlePacketCallback_t );
 
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+}
+
+/**
+ * @brief _preprocessUrcData - urcDataCallback returns CELLULAR_PKT_STATUS_PREFIX_MISMATCH.
+ *
+ * CELLULAR_PKT_STATUS_PREFIX_MISMATCH is returned by the callback function. Verify
+ * that RX thread keep process the data.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( pktStatus == CELLULAR_PKT_STATUS_PREFIX_MISMATCH )
+ * {
+ *     keepProcess = true;
+ * }
+ * @endcode
+ * ( pktStatus == CELLULAR_PKT_STATUS_PREFIX_MISMATCH ) is true.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_prefix_mismatch( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* RX data event for RX thread. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+
+    /* Setup the URC data callback for testing. */
+    context.urcDataCallback = cellularUrcDataCallback;
+    context.pUrcDataCallbackContext = NULL;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_NO_RESULT;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_PREFIX_MISMATCH_STR;
+    pUrcDataPkthandlerString = URC_DATA_CALLBACK_PREFIX_MISMATCH_STR;
+    dataUrcPktHandlerCallbackIsCalled = 0;
+
+    /* API call. */
+    pktStatus = _Cellular_PktioInit( &context, prvDataUrcPktHandlerCallback );
+
+    /* Verification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* This test verifies the pktio will continue to process the data in prvDataUrcPktHandlerCallback. */
+    TEST_ASSERT_EQUAL( 1, dataUrcPktHandlerCallbackIsCalled );
+}
+
+/**
+ * @brief _preprocessUrcData - urcDataCallback returns other errors.
+ *
+ * Other error is returned by the callback function. Verify that RX thread stop
+ * processing the data.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * else if( pktStatus != CELLULAR_PKT_STATUS_OK )
+ * {
+ *     ...
+ *     ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
+ *     pContext->pPktioReadPtr = NULL;
+ *     pContext->partialDataRcvdLen = 0;
+ *     keepProcess = false;
+ * }
+ * @endcode
+ * ( pktStatus != CELLULAR_PKT_STATUS_OK ) is true.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_other_error( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* RX data event for RX thread. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+
+    /* Setup the URC data callback for testing. */
+    context.urcDataCallback = cellularUrcDataCallback;
+    context.pUrcDataCallbackContext = NULL;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_NO_RESULT;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_OTHER_ERROR_STR;
+    dataUrcPktHandlerCallbackIsCalled = 0;
+
+    /* API call. */
+    pktStatus = _Cellular_PktioInit( &context, prvDataUrcPktHandlerCallback );
+
+    /* Verification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The pkthandler callback should not be called. */
+    TEST_ASSERT_EQUAL( 0, dataUrcPktHandlerCallbackIsCalled );
+}
+
+/**
+ * @brief _preprocessUrcData - urcDataCallback returns incorrect buffer length.
+ *
+ * Incorrect buffer length is returned by the callback function. Verify that RX
+ * thread stop processing the data.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * else if( bufferLength > *pBytesRead )
+ * {
+ *     ...
+ *     ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
+ *     pContext->pPktioReadPtr = NULL;
+ *     pContext->partialDataRcvdLen = 0;
+ *     keepProcess = false;
+ * }
+ * @endcode
+ * ( bufferLength > *pBytesRead ) is true.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_incorrect_buffer_length( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* RX data event for RX thread. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+
+    /* Setup the URC data callback for testing. */
+    context.urcDataCallback = cellularUrcDataCallback;
+    context.pUrcDataCallbackContext = NULL;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_NO_RESULT;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_INCORRECT_BUFFER_LEN_STR;
+    dataUrcPktHandlerCallbackIsCalled = 0;
+
+    /* API call. */
+    pktStatus = _Cellular_PktioInit( &context, prvDataUrcPktHandlerCallback );
+
+    /* Verification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The pkthandler callback should not be called. */
+    TEST_ASSERT_EQUAL( 0, dataUrcPktHandlerCallbackIsCalled );
+}
+
+/**
+ * @brief _preprocessUrcData - urcDataCallback returns success.
+ *
+ * Callback function successfully handle the URC data line. Verify that RX
+ * thread keep processing the data after the URC data.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * else
+ * {
+ *     ...
+ *     pTempLine = &pTempLine[ bufferLength ];
+ *     *pLine = pTempLine;
+ *     pContext->pPktioReadPtr = *pLine;
+ *
+ *     *pBytesRead = *pBytesRead - bufferLength;
+ * }
+ * @endcode
+ * The else case.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_success( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* RX data event for RX thread. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+
+    /* Setup the URC data callback for testing. */
+    context.urcDataCallback = cellularUrcDataCallback;
+    context.pUrcDataCallbackContext = NULL;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_NO_RESULT;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR""URC_DATA_CALLBACK_LEFT_OVER_STR;
+    pUrcDataPkthandlerString = URC_DATA_CALLBACK_LEFT_OVER_STR;
+    dataUrcPktHandlerCallbackIsCalled = 0;
+
+    /* API call. */
+    pktStatus = _Cellular_PktioInit( &context, prvDataUrcPktHandlerCallback );
+
+    /* Verification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The pkthandler callback should not be called. */
+    TEST_ASSERT_EQUAL( 1, dataUrcPktHandlerCallbackIsCalled );
+}
+
+/**
+ * @brief _preprocessUrcData - urcDataCallback returns size mismatch.
+ *
+ * Callback function returns size mismatch. Verify that the RX thread stop processing
+ * the data and receive more data from comm interface. The callback function will be
+ * called again with more data.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * else if( pktStatus == CELLULAR_PKT_STATUS_SIZE_MISMATCH )
+ * {
+ *     ...
+ *     pContext->pPktioReadPtr = pTempLine;
+ *     pContext->partialDataRcvdLen = *pBytesRead;
+ *     keepProcess = false;
+ * }
+ * @endcode
+ * ( pktStatus == CELLULAR_PKT_STATUS_SIZE_MISMATCH ) is true.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_size_mismatch( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* RX data event for RX thread. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+
+    /* Setup the URC data callback for testing. */
+    context.urcDataCallback = cellularUrcDataCallback;
+    context.pUrcDataCallbackContext = NULL;
+    recvCount = 2;
+    atCmdType = CELLULAR_AT_NO_RESULT;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR_PART1;
+    pCommIntfRecvCustomStringCallback = prvUrcDataCommIntfRecvCallback;
+    dataUrcPktHandlerCallbackIsCalled = 0;
+
+    /* API call. */
+    pktStatus = _Cellular_PktioInit( &context, prvDataUrcPktHandlerCallback );
+
+    /* Verification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The pkthandler callback should not be called. */
+    TEST_ASSERT_EQUAL( 0, dataUrcPktHandlerCallbackIsCalled );
 }
 
 /**

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -955,12 +955,14 @@ static CellularPktStatus_t prvDataUrcPktHandlerCallback( CellularContext_t * pCo
 {
     int compareResult;
 
+    ( void ) pContext;
+
     dataUrcPktHandlerCallbackIsCalled = 1;
 
     /* Verify the atRespType is AT_UNSOLICITED. */
     TEST_ASSERT_EQUAL( AT_UNSOLICITED, atRespType );
 
-    /* Verify the pBuffer contains the same string in pCommIntfRecvCustomString. */
+    /* Verify the pBuffer contains the same string passed in the test. */
     compareResult = strncmp( pBuffer, pUrcDataPkthandlerString, strlen( pBuffer ) );
     TEST_ASSERT_EQUAL( 0, compareResult );
 
@@ -1428,7 +1430,8 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_prefix_mis
     /* Verification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
-    /* This test verifies the pktio will continue to process the data in prvDataUrcPktHandlerCallback. */
+    /* This test verifies that the pktio rx thread will continue to process the
+     * data in the callback function. */
     TEST_ASSERT_EQUAL( 1, dataUrcPktHandlerCallbackIsCalled );
 }
 

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -141,10 +141,10 @@ static void ( * pCommIntfRecvCustomStringCallback )( void ) = NULL;
 
 static bool atCmdStatusUndefindTest = false;
 
-static void * urcDataCallbackContext = NULL;
+static void * inputBufferCallbackContext = NULL;
 
 static int dataUrcPktHandlerCallbackIsCalled = 0;
-static char * pUrcDataPkthandlerString;
+static char * pInputBufferPkthandlerString;
 
 /* Try to Keep this map in Alphabetical order. */
 /* FreeRTOS Cellular Common Library porting interface. */
@@ -901,36 +901,36 @@ CellularPktStatus_t undefinedRespCallback( void * pCallbackContext,
     return undefineReturnStatus;
 }
 
-static CellularPktStatus_t cellularUrcDataCallback( void * pUrcDataCallbackContext,
-                                                    char * pBuffer,
-                                                    uint32_t bufferLength,
-                                                    uint32_t * pUrcDataLength )
+static CellularPktStatus_t cellularInputBufferCallback( void * pInputBufferCallbackContext,
+                                                        char * pBuffer,
+                                                        uint32_t bufferLength,
+                                                        uint32_t * pInputBufferLength )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_FAILURE;
 
     /* Verify the callback context. */
-    TEST_ASSERT_EQUAL( urcDataCallbackContext, pUrcDataCallbackContext );
+    TEST_ASSERT_EQUAL( inputBufferCallbackContext, pInputBufferCallbackContext );
 
     /* Verify the callback context. */
     if( strncmp( pBuffer, URC_DATA_CALLBACK_PREFIX_MISMATCH_STR, bufferLength ) == 0 )
     {
-        *pUrcDataLength = 0;
+        *pInputBufferLength = 0;
         pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
     }
     else if( strncmp( pBuffer, URC_DATA_CALLBACK_OTHER_ERROR_STR, bufferLength ) == 0 )
     {
-        *pUrcDataLength = 0;
+        *pInputBufferLength = 0;
         pktStatus = CELLULAR_PKT_STATUS_FAILURE;
     }
     else if( strncmp( pBuffer, URC_DATA_CALLBACK_INCORRECT_BUFFER_LEN_STR, bufferLength ) == 0 )
     {
         /* Return incorrect buffer length. */
-        *pUrcDataLength = bufferLength + 1;
+        *pInputBufferLength = bufferLength + 1;
         pktStatus = CELLULAR_PKT_STATUS_OK;
     }
     else if( strncmp( pBuffer, URC_DATA_CALLBACK_MATCH_STR, URC_DATA_CALLBACK_MATCH_STR_LENGTH ) == 0 )
     {
-        *pUrcDataLength = 15;
+        *pInputBufferLength = 15;
         pktStatus = CELLULAR_PKT_STATUS_OK;
     }
     else if( strncmp( pBuffer, URC_DATA_CALLBACK_MATCH_STR_PREFIX, URC_DATA_CALLBACK_MATCH_STR_PREFIX_LENGTH ) == 0 )
@@ -941,7 +941,7 @@ static CellularPktStatus_t cellularUrcDataCallback( void * pUrcDataCallbackConte
         }
         else if( bufferLength == URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH )
         {
-            *pUrcDataLength = URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH;
+            *pInputBufferLength = URC_DATA_CALLBACK_MATCH_STR_PART_LENGTH;
             pktStatus = CELLULAR_PKT_STATUS_OK;
         }
     }
@@ -963,13 +963,13 @@ static CellularPktStatus_t prvDataUrcPktHandlerCallback( CellularContext_t * pCo
     TEST_ASSERT_EQUAL( AT_UNSOLICITED, atRespType );
 
     /* Verify the pBuffer contains the same string passed in the test. */
-    compareResult = strncmp( pBuffer, pUrcDataPkthandlerString, strlen( pBuffer ) );
+    compareResult = strncmp( pBuffer, pInputBufferPkthandlerString, strlen( pBuffer ) );
     TEST_ASSERT_EQUAL( 0, compareResult );
 
     return CELLULAR_PKT_STATUS_OK;
 }
 
-static void prvUrcDataCommIntfRecvCallback( void )
+static void prvInputBufferCommIntfRecvCallback( void )
 {
     pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR_PART2;
 }
@@ -1381,7 +1381,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_pktDataPrefixCB__Test( void )
 }
 
 /**
- * @brief _preprocessUrcData - urcDataCallback returns CELLULAR_PKT_STATUS_PREFIX_MISMATCH.
+ * @brief _preprocessInputBuffer - inputBufferCallback returns CELLULAR_PKT_STATUS_PREFIX_MISMATCH.
  *
  * CELLULAR_PKT_STATUS_PREFIX_MISMATCH is returned by the callback function. Verify
  * that RX thread keep process the data.
@@ -1395,7 +1395,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_pktDataPrefixCB__Test( void )
  * @endcode
  * ( pktStatus == CELLULAR_PKT_STATUS_PREFIX_MISMATCH ) is true.
  */
-void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_prefix_mismatch( void )
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessInputBuffer_prefix_mismatch( void )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularContext_t context;
@@ -1415,13 +1415,13 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_prefix_mis
     pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
 
     /* Setup the URC data callback for testing. */
-    context.urcDataCallback = cellularUrcDataCallback;
-    context.pUrcDataCallbackContext = NULL;
+    context.inputBufferCallback = cellularInputBufferCallback;
+    context.pInputBufferCallbackContext = NULL;
     recvCount = 1;
     atCmdType = CELLULAR_AT_NO_RESULT;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
     pCommIntfRecvCustomString = URC_DATA_CALLBACK_PREFIX_MISMATCH_STR;
-    pUrcDataPkthandlerString = URC_DATA_CALLBACK_PREFIX_MISMATCH_STR;
+    pInputBufferPkthandlerString = URC_DATA_CALLBACK_PREFIX_MISMATCH_STR;
     dataUrcPktHandlerCallbackIsCalled = 0;
 
     /* API call. */
@@ -1436,7 +1436,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_prefix_mis
 }
 
 /**
- * @brief _preprocessUrcData - urcDataCallback returns other errors.
+ * @brief _preprocessInputBuffer - inputBufferCallback returns other errors.
  *
  * Other error is returned by the callback function. Verify that RX thread stop
  * processing the data.
@@ -1454,7 +1454,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_prefix_mis
  * @endcode
  * ( pktStatus != CELLULAR_PKT_STATUS_OK ) is true.
  */
-void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_other_error( void )
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessInputBuffer_other_error( void )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularContext_t context;
@@ -1474,8 +1474,8 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_other_erro
     pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
 
     /* Setup the URC data callback for testing. */
-    context.urcDataCallback = cellularUrcDataCallback;
-    context.pUrcDataCallbackContext = NULL;
+    context.inputBufferCallback = cellularInputBufferCallback;
+    context.pInputBufferCallbackContext = NULL;
     recvCount = 1;
     atCmdType = CELLULAR_AT_NO_RESULT;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
@@ -1493,7 +1493,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_other_erro
 }
 
 /**
- * @brief _preprocessUrcData - urcDataCallback returns incorrect buffer length.
+ * @brief _preprocessInputBuffer - inputBufferCallback returns incorrect buffer length.
  *
  * Incorrect buffer length is returned by the callback function. Verify that RX
  * thread stop processing the data.
@@ -1511,7 +1511,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_other_erro
  * @endcode
  * ( bufferLength > *pBytesRead ) is true.
  */
-void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_incorrect_buffer_length( void )
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessInputBuffer_incorrect_buffer_length( void )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularContext_t context;
@@ -1531,8 +1531,8 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_incorrect_
     pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
 
     /* Setup the URC data callback for testing. */
-    context.urcDataCallback = cellularUrcDataCallback;
-    context.pUrcDataCallbackContext = NULL;
+    context.inputBufferCallback = cellularInputBufferCallback;
+    context.pInputBufferCallbackContext = NULL;
     recvCount = 1;
     atCmdType = CELLULAR_AT_NO_RESULT;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
@@ -1550,7 +1550,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_incorrect_
 }
 
 /**
- * @brief _preprocessUrcData - urcDataCallback returns success.
+ * @brief _preprocessInputBuffer - inputBufferCallback returns success.
  *
  * Callback function successfully handle the URC data line. Verify that RX
  * thread keep processing the data after the URC data.
@@ -1569,7 +1569,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_incorrect_
  * @endcode
  * The else case.
  */
-void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_success( void )
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessInputBuffer_success( void )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularContext_t context;
@@ -1589,13 +1589,13 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_success( v
     pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
 
     /* Setup the URC data callback for testing. */
-    context.urcDataCallback = cellularUrcDataCallback;
-    context.pUrcDataCallbackContext = NULL;
+    context.inputBufferCallback = cellularInputBufferCallback;
+    context.pInputBufferCallbackContext = NULL;
     recvCount = 1;
     atCmdType = CELLULAR_AT_NO_RESULT;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
     pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR ""URC_DATA_CALLBACK_LEFT_OVER_STR;
-    pUrcDataPkthandlerString = URC_DATA_CALLBACK_LEFT_OVER_STR;
+    pInputBufferPkthandlerString = URC_DATA_CALLBACK_LEFT_OVER_STR;
     dataUrcPktHandlerCallbackIsCalled = 0;
 
     /* API call. */
@@ -1609,7 +1609,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_success( v
 }
 
 /**
- * @brief _preprocessUrcData - urcDataCallback returns size mismatch.
+ * @brief _preprocessInputBuffer - inputBufferCallback returns size mismatch.
  *
  * Callback function returns size mismatch. Verify that the RX thread stop processing
  * the data and receive more data from comm interface. The callback function will be
@@ -1627,7 +1627,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_success( v
  * @endcode
  * ( pktStatus == CELLULAR_PKT_STATUS_SIZE_MISMATCH ) is true.
  */
-void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_size_mismatch( void )
+void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessInputBuffer_size_mismatch( void )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularContext_t context;
@@ -1647,13 +1647,13 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event__preprocessUrcData_size_misma
     pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
 
     /* Setup the URC data callback for testing. */
-    context.urcDataCallback = cellularUrcDataCallback;
-    context.pUrcDataCallbackContext = NULL;
+    context.inputBufferCallback = cellularInputBufferCallback;
+    context.pInputBufferCallbackContext = NULL;
     recvCount = 2;
     atCmdType = CELLULAR_AT_NO_RESULT;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
     pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR_PART1;
-    pCommIntfRecvCustomStringCallback = prvUrcDataCommIntfRecvCallback;
+    pCommIntfRecvCustomStringCallback = prvInputBufferCommIntfRecvCallback;
     dataUrcPktHandlerCallbackIsCalled = 0;
 
     /* API call. */


### PR DESCRIPTION
Adding _Cellular_RegisterInputBufferCallback to handle data stream in URC response referenced in #123.

Cellular modem may return binary data in URC.
For example, BG96 allows to receive the socket data in URC with direct push mode.
```
+QIURC: "recv",0,4 //Receive data from remote server.
test   // URC DATA , it can be binary stream.
```
The binary data can't be handled by cellular pktio since it handles data in line. Binary stream can only be handled in AT command response not in URC.
This PR makes use of a callback function to pass the input buffer received to the port. The port can decide to handle the input buffer in the callback or return to pktio for further parsing.

Module porting callback can return the following value to the pktio:
* **CELLULAR_PKT_STATUS_PREFIX_MISMATCH** : indicates the input buffer in not handled in the callback. pktio will continue to process the line in the input buffer.
```
+CREG:2    // Cellular interface is able to handle URC +CREG. 
           // The input buffer callback can returns CELLULAR_PKT_STATUS_PREFIX_MISMATCH to pktio for further processing.
```
* **CELLULAR_PKT_STATUS_SIZE_MISMATCH** : indicates the input buffer is handled in the callback but more data is expected. pktio will stop processing this input buffer. The callback function will be called again when more data is received.
```
+QIURC: "recv",0,4
te    // In previous example, the URC expect 4 bytes of binary data but only 2 bytes received
      // The input buffer callback can returns CELLULAR_PKT_STATUS_SIZE_MISMATCH.
      // It will be called again when more data received ( "st" is received )
```
* **CELLULAR_PKT_STATUS_OK** : indicates that the input buffer is handled in the callback successfully. The pktio will keep processing the line after.
```
+QIURC: "recv",0,4
test
+CREG:2           // The +QIURC is handled in the callback function. The callback function returns CELLULAR_PKT_STATUS_OK.
                  // pktio will continue to process the "+CREG:2"
```
* **Other errors** : indicates that modem returns unexpected error.


Description
-----------
* Adding **_Cellular_RegisterInputBufferCallback**  in common layer for porting to handle the input buffer before pktio.
* Module porting can make use of this API in common layer to handle data in URC. Reference [the example](https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface-Reference-Quectel-BG96/pull/10/files) in BG96 for usage.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
