### PR TITLE
Support AT command with no success result code

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -39,12 +39,12 @@
     </tr>
     <tr>
         <td>cellular_pktio.c</td>
-        <td><center>2.1K</center></td>
+        <td><center>2.2K</center></td>
         <td><center>1.9K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>14.9K</center></b></td>
+        <td><b><center>15.0K</center></b></td>
         <td><b><center>13.6K</center></b></td>
     </tr>
 </table>

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -640,6 +640,8 @@ prl
 processmodemrdy
 processpowerdown
 prssivalue
+prvpacketcallbackerror
+prvpacketcallbacksuccess
 ps
 psaveptr
 psentdatalength

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -504,6 +504,7 @@ pclosedcallbackcontext
 pcomminterface
 pcomminterfacehandle
 pcommintf
+pcommintfrecvcustomstring
 pcontext
 pcomparestring
 pcurrentcmd
@@ -545,6 +546,7 @@ pinputptr
 pinputstr
 pitm
 pkio
+pkstatus
 pkt
 pktdataprefixcallback
 pktdataprefixcb

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -205,6 +205,26 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
 
             break;
 
+        case CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE:
+
+            if( pResp->pItm == NULL )
+            {
+                _saveATData( pLine, pResp );
+
+                /* This command only expect one response and no result code. */
+                pResp->status = true;
+                pkStatus = CELLULAR_PKT_STATUS_OK;
+            }
+            else
+            {
+                /* We already have an intermediate response. */
+                pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
+                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %s, status: %d, previous line %s",
+                            pLine, pkStatus, pResp->pItm->pLine ) );
+            }
+
+            break;
+
         case CELLULAR_AT_WITH_PREFIX:
 
             if( pResp->pItm == NULL )
@@ -213,6 +233,30 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
                  * function _getMsgType(), so the failure condition here won't be touched.
                  */
                 _saveATData( pLine, pResp );
+            }
+            else
+            {
+                /* We already have an intermediate response. */
+                pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
+                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %s, status: %d, previous line %s",
+                            pLine, pkStatus, pResp->pItm->pLine ) );
+            }
+
+            break;
+
+        case CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE:
+
+            if( pResp->pItm == NULL )
+            {
+                /* The removed code which demonstrate the existence of the prefix has been done in
+                 * function _getMsgType(), so the failure condition here won't be touched.
+                 */
+                _saveATData( pLine, pResp );
+
+                /* This command only expect one response and no result code. */
+                pResp->status = true;
+                pkStatus = CELLULAR_PKT_STATUS_OK;
+                
             }
             else
             {

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -388,7 +388,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
                 pkStatus = _processIntermediateResponse( pLine, pResp, atType );
 
                 /* This is the case that no final result code is expected. The AT
-                 * command only expect one resonse from modem. */
+                 * command only expect one response from modem. */
                 if( pkStatus == CELLULAR_PKT_STATUS_OK )
                 {
                     pResp->status = true;

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -486,7 +486,8 @@ static _atRespType_t _getMsgType( CellularContext_t * pContext,
             if( ( ( pContext->PktioAtCmdType != CELLULAR_AT_NO_COMMAND ) && ( pRespPrefix == NULL ) ) ||
                 ( pContext->PktioAtCmdType == CELLULAR_AT_MULTI_DATA_WO_PREFIX ) ||
                 ( pContext->PktioAtCmdType == CELLULAR_AT_WITH_PREFIX ) ||
-                ( pContext->PktioAtCmdType == CELLULAR_AT_MULTI_WITH_PREFIX ) )
+                ( pContext->PktioAtCmdType == CELLULAR_AT_MULTI_WITH_PREFIX ) ||
+                ( pContext->PktioAtCmdType == CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE ) )
             {
                 atRespType = AT_SOLICITED;
             }

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -252,11 +252,14 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
 
         case CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE:
         case CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE:
+            /* Save the line in the response. */
             _saveATData( pLine, pResp );
 
             /* Returns CELLULAR_PKT_STATUS_OK to indicate that the response of the
-             * command is received. */
+             * command is received. No success result code is expected. Set the response
+             * status to true here. */
             pkStatus = CELLULAR_PKT_STATUS_OK;
+            pResp->status = true;
             break;
 
         default:
@@ -383,27 +386,20 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
                 pResp->status = false;
                 pkStatus = CELLULAR_PKT_STATUS_OK;
             }
-            else
-            {
-                pkStatus = _processIntermediateResponse( pLine, pResp, atType );
+        }
 
-                /* This is the case that no final result code is expected. The AT
-                 * command only expect one response from modem. */
-                if( pkStatus == CELLULAR_PKT_STATUS_OK )
-                {
-                    pResp->status = true;
-                }
-            }
+        if( result != true )
+        {
+            pkStatus = _processIntermediateResponse( pLine, pResp, atType );
         }
     }
 
     if( ( result == true ) && ( pResp->status == false ) )
     {
-        LogWarn( ( "Modem return ERROR: line %s, cmd : %s, respPrefix %s, status: %d",
-                   ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ),
+        LogWarn( ( "Modem return ERROR: line %s, cmd : %s, respPrefix %s",
                    pLine,
-                   ( pRespPrefix != NULL ? pRespPrefix : "NULL" ),
-                   pkStatus ) );
+                   ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ),
+                   ( pRespPrefix != NULL ? pRespPrefix : "NULL" ) ) );
     }
 
     PlatformMutex_Unlock( &pContext->PktRespMutex );

--- a/source/include/cellular_types.h
+++ b/source/include/cellular_types.h
@@ -358,13 +358,15 @@ typedef enum CellularPktStatus
  */
 typedef enum CellularATCommandType
 {
-    CELLULAR_AT_NO_RESULT,            /**<  no response expected, only OK, ERROR etc. */
-    CELLULAR_AT_WO_PREFIX,            /**<  string response without a prefix. */
-    CELLULAR_AT_WITH_PREFIX,          /**<  string response with a prefix. */
-    CELLULAR_AT_MULTI_WITH_PREFIX,    /**<  multiple line response all start with a prefix. */
-    CELLULAR_AT_MULTI_WO_PREFIX,      /**<  multiple line response with or without a prefix. */
-    CELLULAR_AT_MULTI_DATA_WO_PREFIX, /**<  multiple line data response with or without a prefix. */
-    CELLULAR_AT_NO_COMMAND            /**<  no command is waiting response. */
+    CELLULAR_AT_NO_RESULT,                    /**<  no response expected, only OK, ERROR etc. */
+    CELLULAR_AT_WO_PREFIX,                    /**<  string response without a prefix. */
+    CELLULAR_AT_WITH_PREFIX,                  /**<  string response with a prefix. */
+    CELLULAR_AT_MULTI_WITH_PREFIX,            /**<  multiple line response all start with a prefix. */
+    CELLULAR_AT_MULTI_WO_PREFIX,              /**<  multiple line response with or without a prefix. */
+    CELLULAR_AT_MULTI_DATA_WO_PREFIX,         /**<  multiple line data response with or without a prefix. */
+    CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE,     /**<  string response without a prefix and no result code is expected. */
+    CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE,   /**<  string response WITH a prefix and no result code is expected. */
+    CELLULAR_AT_NO_COMMAND                    /**<  no command is waiting response. */
 } CellularATCommandType_t;
 
 /**

--- a/source/include/cellular_types.h
+++ b/source/include/cellular_types.h
@@ -358,15 +358,15 @@ typedef enum CellularPktStatus
  */
 typedef enum CellularATCommandType
 {
-    CELLULAR_AT_NO_RESULT,                    /**<  no response expected, only OK, ERROR etc. */
-    CELLULAR_AT_WO_PREFIX,                    /**<  string response without a prefix. */
-    CELLULAR_AT_WITH_PREFIX,                  /**<  string response with a prefix. */
-    CELLULAR_AT_MULTI_WITH_PREFIX,            /**<  multiple line response all start with a prefix. */
-    CELLULAR_AT_MULTI_WO_PREFIX,              /**<  multiple line response with or without a prefix. */
-    CELLULAR_AT_MULTI_DATA_WO_PREFIX,         /**<  multiple line data response with or without a prefix. */
-    CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE,     /**<  string response without a prefix and no result code is expected. */
-    CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE,   /**<  string response WITH a prefix and no result code is expected. */
-    CELLULAR_AT_NO_COMMAND                    /**<  no command is waiting response. */
+    CELLULAR_AT_NO_RESULT,                  /**<  no response expected, only OK, ERROR etc. */
+    CELLULAR_AT_WO_PREFIX,                  /**<  string response without a prefix. */
+    CELLULAR_AT_WITH_PREFIX,                /**<  string response with a prefix. */
+    CELLULAR_AT_MULTI_WITH_PREFIX,          /**<  multiple line response all start with a prefix. */
+    CELLULAR_AT_MULTI_WO_PREFIX,            /**<  multiple line response with or without a prefix. */
+    CELLULAR_AT_MULTI_DATA_WO_PREFIX,       /**<  multiple line data response with or without a prefix. */
+    CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE,   /**<  string response without a prefix and no result code is expected. */
+    CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE, /**<  string response WITH a prefix and no result code is expected. */
+    CELLULAR_AT_NO_COMMAND                  /**<  no command is waiting response. */
 } CellularATCommandType_t;
 
 /**

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -2189,7 +2189,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_STRING_
  * @brief _processIntermediateResponse - Successfully handle AT command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE.
  *
  * Successfully handle at command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE. Verify
- * the respones string in the callback function.
+ * the response string in the callback function.
  *
  * <b>Coverage</b>
  * @code{c}
@@ -2197,7 +2197,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_STRING_
  *             ...
  *             _saveATData( pLine, pResp );
  *
- *             pkStatus = CELLULAR_PKT_STATUS_OK;
+ *             pktStatus = CELLULAR_PKT_STATUS_OK;
  *             break;
  * @endcode
  * The CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE case.
@@ -2228,7 +2228,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackSuccess );
 
-    /* Veification. */
+    /* Verification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
     /* The result is verified in prvPacketCallbackSuccess. */
@@ -2265,7 +2265,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackError );
 
-    /* Veification. */
+    /* Verification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
     /* The result is verified in prvPacketCallbackError. */
@@ -2276,7 +2276,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
  * @brief _processIntermediateResponse - Successfully handle AT command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE.
  *
  * Successfully handle at command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE. Verify
- * the respones string in the callback function.
+ * the response string in the callback function.
  *
  * <b>Coverage</b>
  * @code{c}
@@ -2315,7 +2315,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RE
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackSuccess );
 
-    /* Veification. */
+    /* Verification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
     /* The result is verified in prvPacketCallbackSuccess. */
@@ -2353,7 +2353,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RE
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackError );
 
-    /* Veification. */
+    /* Verification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
     /* The result is verified in prvPacketCallbackError. */

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -2163,6 +2163,23 @@ static CellularPktStatus_t prvHandlePacketCallback( CellularContext_t * pContext
     return CELLULAR_PKT_STATUS_OK;
 }
 
+/**
+ * @brief _processIntermediateResponse - Successfully handle at command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE.
+ *
+ * Successfully handle at command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE. Verify
+ * the respones string in the callback function.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ *         case CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE:
+ *             ...
+ *             _saveATData( pLine, pResp );
+ *
+ *             pkStatus = CELLULAR_PKT_STATUS_OK;
+ *             break;
+ * @endcode
+ * The CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE case.
+ */
 void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE_success( void )
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
@@ -2185,6 +2202,55 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
     atCmdType = CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
     pCommIntfRecvCustomString = "12345\r\n";    /* Dummy string to be verified in the callback. */
+
+    /* Check that CELLULAR_PKT_STATUS_OK is returned. */
+    pktStatus = _Cellular_PktioInit( &context, prvHandlePacketCallback );
+
+    /* Veification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The result is verified in prvHandlePacketCallback. */
+}
+
+/**
+ * @brief _processIntermediateResponse - Successfully handle at command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE.
+ *
+ * Successfully handle at command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE. Verify
+ * the respones string in the callback function.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ *         case CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE:
+ *             _saveATData( pLine, pResp );
+ *
+ *             pkStatus = CELLULAR_PKT_STATUS_OK;
+ *             break;
+ * @endcode
+ * The CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE case.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE_success( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* Test the rx_data event with CELLULAR_AT_WO_PREFIX resp. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    context.pRespPrefix = "+CMD_PREFIX";
+    pCommIntfRecvCustomString = "+CMD_PREFIX:12345\r\n";    /* Dummy string to be verified in the callback. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvHandlePacketCallback );

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -979,6 +979,7 @@ static CellularPktStatus_t prvPacketCallbackError( CellularContext_t * pContext,
                                                    const void * pBuffer )
 {
     const CellularATCommandResponse_t * pAtResp = ( const CellularATCommandResponse_t * ) pBuffer;
+
     ( void ) pContext;
 
     /* Verify the response type is AT_SOLICITED. */
@@ -2223,7 +2224,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
     recvCount = 1;
     atCmdType = CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
-    pCommIntfRecvCustomString = "12345\r\n";    /* Dummy string to be verified in the callback. */
+    pCommIntfRecvCustomString = "12345\r\n"; /* Dummy string to be verified in the callback. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackSuccess );
@@ -2260,7 +2261,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
     recvCount = 1;
     atCmdType = CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
-    pCommIntfRecvCustomString = "ERROR\r\n";            /* Return one of the error token. */
+    pCommIntfRecvCustomString = "ERROR\r\n"; /* Return one of the error token. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackError );
@@ -2310,7 +2311,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RE
     atCmdType = CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
     context.pRespPrefix = "+CMD_PREFIX";
-    pCommIntfRecvCustomString = "+CMD_PREFIX:12345\r\n";    /* Dummy string to be verified in the callback. */
+    pCommIntfRecvCustomString = "+CMD_PREFIX:12345\r\n"; /* Dummy string to be verified in the callback. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackSuccess );
@@ -2348,7 +2349,7 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RE
     atCmdType = CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE;
     testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
     context.pRespPrefix = "+CMD_PREFIX";
-    pCommIntfRecvCustomString = "ERROR\r\n";    /* Return one of the error token. */
+    pCommIntfRecvCustomString = "ERROR\r\n"; /* Return one of the error token. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
     pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackError );

--- a/test/unit-test/cellular_pktio_utest.c
+++ b/test/unit-test/cellular_pktio_utest.c
@@ -974,6 +974,50 @@ static void prvInputBufferCommIntfRecvCallback( void )
     pCommIntfRecvCustomString = URC_DATA_CALLBACK_MATCH_STR_PART2;
 }
 
+static CellularPktStatus_t prvPacketCallbackError( CellularContext_t * pContext,
+                                                   _atRespType_t atRespType,
+                                                   const void * pBuffer )
+{
+    const CellularATCommandResponse_t * pAtResp = ( const CellularATCommandResponse_t * ) pBuffer;
+    ( void ) pContext;
+
+    /* Verify the response type is AT_SOLICITED. */
+    TEST_ASSERT_EQUAL( AT_SOLICITED, atRespType );
+
+    /* Verify that no item is added to the response. */
+    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp );
+    TEST_ASSERT_EQUAL( NULL, pAtResp->pItm );
+
+    /* Verify that the response indicate error. */
+    TEST_ASSERT_EQUAL( false, pAtResp->status );
+
+    return CELLULAR_PKT_STATUS_OK;
+}
+
+static CellularPktStatus_t prvPacketCallbackSuccess( CellularContext_t * pContext,
+                                                     _atRespType_t atRespType,
+                                                     const void * pBuffer )
+{
+    const CellularATCommandResponse_t * pAtResp = ( const CellularATCommandResponse_t * ) pBuffer;
+    int cmpResult;
+
+    ( void ) pContext;
+
+    /* Verify the response type is AT_SOLICITED. */
+    TEST_ASSERT_EQUAL( AT_SOLICITED, atRespType );
+
+    /* Verify the string is the same as expected. */
+    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp );
+    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp->pItm );
+    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp->pItm->pLine );
+    cmpResult = strncmp( pAtResp->pItm->pLine, pCommIntfRecvCustomString, strlen( pAtResp->pItm->pLine ) );
+    TEST_ASSERT_EQUAL( 0, cmpResult );
+
+    /* Verify that the response indicate error. */
+    TEST_ASSERT_EQUAL( true, pAtResp->status );
+
+    return CELLULAR_PKT_STATUS_OK;
+}
 
 /* ========================================================================== */
 
@@ -2141,30 +2185,8 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_STRING_
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 }
 
-static CellularPktStatus_t prvHandlePacketCallback( CellularContext_t * pContext,
-                                                    _atRespType_t atRespType,
-                                                    const void * pBuffer )
-{
-    const CellularATCommandResponse_t * pAtResp = ( const CellularATCommandResponse_t * ) pBuffer;
-    int cmpResult;
-
-    ( void ) pContext;
-
-    /* Verify the response type is AT_SOLICITED. */
-    TEST_ASSERT_EQUAL( AT_SOLICITED, atRespType );
-
-    /* Verify the string is the same as expected. */
-    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp );
-    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp->pItm );
-    TEST_ASSERT_NOT_EQUAL( NULL, pAtResp->pItm->pLine );
-    cmpResult = strncmp( pAtResp->pItm->pLine, pCommIntfRecvCustomString, strlen( pAtResp->pItm->pLine ) );
-    TEST_ASSERT_EQUAL( 0, cmpResult );
-
-    return CELLULAR_PKT_STATUS_OK;
-}
-
 /**
- * @brief _processIntermediateResponse - Successfully handle at command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE.
+ * @brief _processIntermediateResponse - Successfully handle AT command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE.
  *
  * Successfully handle at command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE. Verify
  * the respones string in the callback function.
@@ -2204,16 +2226,54 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESU
     pCommIntfRecvCustomString = "12345\r\n";    /* Dummy string to be verified in the callback. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
-    pktStatus = _Cellular_PktioInit( &context, prvHandlePacketCallback );
+    pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackSuccess );
 
     /* Veification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
-    /* The result is verified in prvHandlePacketCallback. */
+    /* The result is verified in prvPacketCallbackSuccess. */
 }
 
 /**
- * @brief _processIntermediateResponse - Successfully handle at command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE.
+ * @brief _processIntermediateResponse - Modem returns error when sending AT command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE.
+ *
+ * Modem returns error when sending AT command type CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE_error( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* Test the rx_data event with CELLULAR_AT_WO_PREFIX resp. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    pCommIntfRecvCustomString = "ERROR\r\n";            /* Return one of the error token. */
+
+    /* Check that CELLULAR_PKT_STATUS_OK is returned. */
+    pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackError );
+
+    /* Veification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The result is verified in prvPacketCallbackError. */
+}
+
+
+/**
+ * @brief _processIntermediateResponse - Successfully handle AT command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE.
  *
  * Successfully handle at command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE. Verify
  * the respones string in the callback function.
@@ -2253,12 +2313,50 @@ void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RE
     pCommIntfRecvCustomString = "+CMD_PREFIX:12345\r\n";    /* Dummy string to be verified in the callback. */
 
     /* Check that CELLULAR_PKT_STATUS_OK is returned. */
-    pktStatus = _Cellular_PktioInit( &context, prvHandlePacketCallback );
+    pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackSuccess );
 
     /* Veification. */
     TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
 
-    /* The result is verified in prvHandlePacketCallback. */
+    /* The result is verified in prvPacketCallbackSuccess. */
+}
+
+/**
+ * @brief _processIntermediateResponse - Modem returns error when sending AT command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE.
+ *
+ * Modem returns error when sending AT command type CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE.
+ */
+void test__Cellular_PktioInit_Thread_Rx_Data_Event_CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE_error( void )
+{
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularContext_t context;
+    CellularCommInterface_t * pCommIntf = &CellularCommInterface;
+
+    threadReturn = true;
+    memset( &context, 0, sizeof( CellularContext_t ) );
+
+    /* copy the token table. */
+    ( void ) memcpy( &context.tokenTable, &tokenTable, sizeof( CellularTokenTable_t ) );
+
+    /* Assign the comm interface to pContext. */
+    context.pCommIntf = pCommIntf;
+    context.pPktioShutdownCB = _shutdownCallback;
+
+    /* Test the rx_data event with CELLULAR_AT_WO_PREFIX resp. */
+    pktioEvtMask = PKTIO_EVT_MASK_RX_DATA;
+    recvCount = 1;
+    atCmdType = CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE;
+    testCommIfRecvType = COMM_IF_RECV_CUSTOM_STRING;
+    context.pRespPrefix = "+CMD_PREFIX";
+    pCommIntfRecvCustomString = "ERROR\r\n";    /* Return one of the error token. */
+
+    /* Check that CELLULAR_PKT_STATUS_OK is returned. */
+    pktStatus = _Cellular_PktioInit( &context, prvPacketCallbackError );
+
+    /* Veification. */
+    TEST_ASSERT_EQUAL( CELLULAR_PKT_STATUS_OK, pktStatus );
+
+    /* The result is verified in prvPacketCallbackError. */
 }
 
 /**


### PR DESCRIPTION
This PR adds no success result code command to support the issue #128.

Some cellular modem has command that doesn't reply success result code like "OK" to indicate status.
In the example, SIM8000C has AT+CIFSR command that only returns IP address.
```
AT+CIFSR
100.83.218.17   // Only IP address is returned in the response. No success result code.
```
Error result code is still returned by the modem.
```
AT+CIFSR
ERROR // Error result code is returned by modem
```

This PR add two new AT command types CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE  and CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE to support this kind of cellular modem. If response is received, this command is regarded as success the response callback will be called. No success result code is required.


Description
-----------
* Add CELLULAR_AT_WO_PREFIX_NO_RESULT_CODE AT command type.
* Add CELLULAR_AT_WITH_PREFIX_NO_RESULT_CODE AT command type.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
