### PR TITLE
Make CELLULAR_AT_MAX_STRING_SIZE configurable

### DIFF
--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -441,6 +441,18 @@
 #endif
 
 /**
+ * @brief Cellular AT string length.<br>
+ *
+ * The maximum length of an AT string.<br>
+ *
+ * <b>Possible values:</b>`Any positive integer`<br>
+ * <b>Default value (if undefined):</b> 256
+ */
+#ifndef CELLULAR_AT_MAX_STRING_SIZE
+    #define CELLULAR_AT_MAX_STRING_SIZE    ( 256U )
+#endif
+
+/**
  * @brief Macro that is called in the cellular library for logging "Error" level
  * messages.
  *

--- a/source/include/common/cellular_at_core.h
+++ b/source/include/common/cellular_at_core.h
@@ -45,17 +45,14 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Cellular includes. */
+#ifndef CELLULAR_DO_NOT_USE_CUSTOM_CONFIG
+    /* Include custom config file before other headers. */
+    #include "cellular_config.h"
+#endif
+#include "cellular_config_defaults.h"
+
 /*-----------------------------------------------------------*/
-
-/**
- * @brief Maximum size of an AT string.
- */
-#define CELLULAR_AT_MAX_STRING_SIZE    ( 256U )
-
-/**
- * @brief Maximum size of an AT prefix.
- */
-#define CELLULAR_AT_MAX_PREFIX_SIZE    ( 32 )
 
 /**
  * @brief The array size of an array.

--- a/test/unit-test/cellular_at_core_utest.c
+++ b/test/unit-test/cellular_at_core_utest.c
@@ -889,6 +889,20 @@ void test_Cellular_ATStrStartWith_Empty_Prefix( void )
 }
 
 /**
+ * @brief Test the long string case for Cellular_ATStrStartWith to return CELLULAR_AT_BAD_PARAMETER.
+ */
+void test_Cellular_ATStrStartWith_ATStringTooLong( void )
+{
+    CellularATError_t cellularStatus = CELLULAR_AT_SUCCESS;
+    bool result;
+    char * pPrefix = "";
+    char pStringSuccess[] = CELLULAR_SAMPLE_PREFIX_STRING_LARGE_INPUT;
+
+    cellularStatus = Cellular_ATStrStartWith( pStringSuccess, pPrefix, &result );
+    TEST_ASSERT_EQUAL( CELLULAR_AT_BAD_PARAMETER, cellularStatus );
+}
+
+/**
  * @brief Test that any NULL parameter causes Cellular_ATStrtoi to return CELLULAR_AT_BAD_PARAMETER.
  */
 void test_Cellular_ATStrtoi_Invalid_Param( void )


### PR DESCRIPTION
<!--- Title -->
Make CELLULAR_AT_MAX_STRING_SIZE configurable

Description
-----------
<!--- Describe your changes in detail. -->
- Move CELLULAR_AT_MAX_STRING_SIZE to cellular_config_defaults.h.
- Remove useless MACRO `CELLULAR_AT_MAX_PREFIX_SIZE`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Compile project in FreeRTOS successfully.
- Pass demo with BG96.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
