### PR TITLE
Return IP address list in Cellular_CommonGetIPAddress

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -144,6 +144,7 @@ checkcrsmreadstatus
 checklibrarystatus
 chk
 ci
+cid
 ciev
 clearbits
 closedcallback

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1210,23 +1210,17 @@ static CellularPktStatus_t _Cellular_RecvFuncIpAddress( CellularContext_t * pCon
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "Recv IP address: Context id: %s", pToken ) );
+            LogDebug( ( "Recv IP address: Context id: %s, Address %s", pToken, pInputLine ) );
 
             if( pInputLine[ 0 ] != '\0' )
             {
-                atCoreStatus = Cellular_ATGetNextTok( &pInputLine, &pToken );
+                ( void ) strncpy( pData, pInputLine, dataLen );
             }
             else
             {
-                /* This is the case "+CGPADDR: 1". Return "0.0.0.0" in this case.*/
-                ( void ) strncpy( pData, "0,0,0,0", dataLen );
+                /* This is the case "+CGPADDR: <cid>". Return empty string. */
+                ( void ) memset( pData, 0, dataLen );
             }
-        }
-
-        if( atCoreStatus == CELLULAR_AT_SUCCESS )
-        {
-            LogDebug( ( "Recv IP address: Ip Addr: %s", pToken ) );
-            ( void ) strncpy( pData, pToken, dataLen );
         }
 
         pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );


### PR DESCRIPTION
AT+CGPADDR returns a list of IPV4 and IPV6 address when PDP_type is set to IPV4V6. Update the implementation to return a list of IP addresses.

```
AT+CGDCONT=1,"IPV4V6",""
OK
AT+CGPADDR=1
+CGPADDR: 1,10.174.245.251,2001:B400:E23D:9ADF:9059:ED92:B26E:9C1C   #  <IPv4>,<IPv6> addresses are returned by modem
```

Description
-----------
* Two IP addresses may be returned when PDP_type is set to IPV4V6. A list of IP addresses should be returned.

Test Steps
-----------
```
/* Set the PDP_type to IPV4V6. */
CellularPdnConfig_t pdnConfig = { CELLULAR_PDN_CONTEXT_IPV4V6, CELLULAR_PDN_AUTH_NONE, CELLULAR_APN, "", "" };
...
cellularStatus = Cellular_SetPdnConfig( CellularHandle, CellularSocketPdnContextId, &pdnConfig );
...
cellularStatus = Cellular_GetIPAddress( CellularHandle, CellularSocketPdnContextId, localIP, sizeof( localIP ) );
...
configPRINTF( ( ">>>  Cellular_GetIPAddress %s  <<<\r\n", localIP ) );
```
localIP should contain a list of IP addresses.

```
>>>  Cellular_GetIPAddress 10.175.162.95,2001:B400:E23D:EA13:434B:9420:30EC:5246  <<<
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
