### PR TITLE
Update print log fmt

### DIFF
--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -489,12 +489,13 @@ static CellularPktStatus_t _parseTimeZoneInfo( char * pTimeZoneResp,
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
-        LogDebug( ( "TimeZoneInfo: Timezone %"CELLULAR_LOG_FMT_INT32" Year %"CELLULAR_LOG_FMT_INT32" Month %"CELLULAR_LOG_FMT_INT32" day %"CELLULAR_LOG_FMT_INT32",", pTimeInfo->timeZone,
+        LogDebug( ( "TimeZoneInfo: Timezone %"CELLULAR_LOG_FMT_INT32" Year %"CELLULAR_LOG_FMT_INT" Month %"CELLULAR_LOG_FMT_INT" day %"CELLULAR_LOG_FMT_INT",",
+                    pTimeInfo->timeZone,
                     pTimeInfo->year,
                     pTimeInfo->month,
                     pTimeInfo->day ) );
 
-        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT32" Minute %"CELLULAR_LOG_FMT_INT32" Second %"CELLULAR_LOG_FMT_INT32"",
+        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT" Minute %"CELLULAR_LOG_FMT_INT" Second %"CELLULAR_LOG_FMT_INT"",
                     pTimeInfo->hour,
                     pTimeInfo->minute,
                     pTimeInfo->second ) );
@@ -843,7 +844,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetNetworkReg( CellularContext_t * 
             pCommandLine = pCommandLine->pNext;
         }
 
-        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT32" pktStatus:%"CELLULAR_LOG_FMT_INT32"", regType, pktStatus ) );
+        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT" pktStatus:%"CELLULAR_LOG_FMT_INT"", regType, pktStatus ) );
     }
 
     return pktStatus;
@@ -1319,7 +1320,7 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
         {
             if( parseEidrxToken( pToken, tokenIndex, pEidrxSettingsList, count ) != CELLULAR_AT_SUCCESS )
             {
-                LogInfo( ( "parseEidrxToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_INT32" failed", pToken, tokenIndex ) );
+                LogInfo( ( "parseEidrxToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_INT" failed", pToken, tokenIndex ) );
             }
 
             tokenIndex++;
@@ -1333,13 +1334,13 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
 
     if( atCoreStatus == CELLULAR_AT_SUCCESS )
     {
-        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT32"]: RAT: %"CELLULAR_LOG_FMT_INT32", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX"",
+        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT"]: RAT: %"CELLULAR_LOG_FMT_INT", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX"",
                     count, pEidrxSettingsList->eidrxList[ count ].rat,
                     pEidrxSettingsList->eidrxList[ count ].requestedEdrxValue ) );
     }
     else
     {
-        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT32"", atCoreStatus ) );
+        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT"", atCoreStatus ) );
     }
 
     return atCoreStatus;
@@ -1694,7 +1695,7 @@ CellularError_t Cellular_CommonSetEidrxSettings( CellularHandle_t cellularHandle
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT32",%"CELLULAR_LOG_FMT_INT32",\"" PRINTF_BINARY_PATTERN_INT4 "\"",
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT",%"CELLULAR_LOG_FMT_INT",\"" PRINTF_BINARY_PATTERN_INT4 "\"",
                            "AT+CEDRXS=",
                            pEidrxSettings->mode,
                            pEidrxSettings->rat,
@@ -1855,14 +1856,14 @@ CellularError_t Cellular_CommonGetServiceStatus( CellularHandle_t cellularHandle
         ( void ) strncpy( pServiceStatus->operatorName, operatorInfo.operatorName, CELLULAR_NETWORK_NAME_MAX_SIZE );
         pServiceStatus->operatorNameFormat = operatorInfo.operatorNameFormat;
 
-        LogDebug( ( "SrvStatus: rat %"CELLULAR_LOG_FMT_INT32" cs %"CELLULAR_LOG_FMT_INT32", ps %"CELLULAR_LOG_FMT_INT32", mode %"CELLULAR_LOG_FMT_INT32", csRejType %"CELLULAR_LOG_FMT_INT32",",
+        LogDebug( ( "SrvStatus: rat %"CELLULAR_LOG_FMT_INT" cs %"CELLULAR_LOG_FMT_INT", ps %"CELLULAR_LOG_FMT_INT", mode %"CELLULAR_LOG_FMT_INT", csRejType %"CELLULAR_LOG_FMT_INT",",
                     pServiceStatus->rat,
                     pServiceStatus->csRegistrationStatus,
                     pServiceStatus->psRegistrationStatus,
                     pServiceStatus->networkRegistrationMode,
                     pServiceStatus->csRejectionType ) );
 
-        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT32", psRejType %"CELLULAR_LOG_FMT_INT32", psRej %"CELLULAR_LOG_FMT_INT32", plmn %"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_STR"",
+        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT", psRejType %"CELLULAR_LOG_FMT_INT", psRej %"CELLULAR_LOG_FMT_INT", plmn %"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_STR"",
                     pServiceStatus->csRejectionCause,
                     pServiceStatus->psRejectionType,
                     pServiceStatus->psRejectionCause,
@@ -2048,13 +2049,13 @@ CellularError_t Cellular_CommonGetIPAddress( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT32"", "AT+CGPADDR=", contextId );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT"", "AT+CGPADDR=", contextId );
 
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetIp );
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR", pktStatus: %"CELLULAR_LOG_FMT_INT32"", cmdBuf, pktStatus ) );
+            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR", pktStatus: %"CELLULAR_LOG_FMT_INT"", cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2170,7 +2171,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
                 break;
 
             default:
-                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT32"",
+                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT"",
                             CELLULAR_PDN_CONTEXT_IPV4V6 ) );
                 cellularStatus = CELLULAR_BAD_PARAMETER;
                 break;
@@ -2195,7 +2196,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT32",\"%"CELLULAR_LOG_FMT_STR"\",\"%"CELLULAR_LOG_FMT_STR"\"",
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT",\"%"CELLULAR_LOG_FMT_STR"\",\"%"CELLULAR_LOG_FMT_STR"\"",
                            "AT+CGDCONT=",
                            contextId,
                            pPdpTypeStr,
@@ -2204,7 +2205,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR", PktRet: %"CELLULAR_LOG_FMT_INT32"", cmdBuf, pktStatus ) );
+            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR", PktRet: %"CELLULAR_LOG_FMT_INT"", cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2685,7 +2686,7 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetSimLockStatus );
 
         cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
-        LogDebug( ( "_Cellular_GetSimStatus, Sim Insert State[%"CELLULAR_LOG_FMT_INT32"], Lock State[%"CELLULAR_LOG_FMT_INT32"]",
+        LogDebug( ( "_Cellular_GetSimStatus, Sim Insert State[%"CELLULAR_LOG_FMT_INT"], Lock State[%"CELLULAR_LOG_FMT_INT"]",
                     pSimCardStatus->simCardState, pSimCardStatus->simCardLockState ) );
     }
 
@@ -2834,7 +2835,7 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%"CELLULAR_LOG_FMT_INT32",", pPsmSettings->mode );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%"CELLULAR_LOG_FMT_INT",", pPsmSettings->mode );
         cmdBufLen = ( uint32_t ) strlen( cmdBuf );
         cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicRauValue, false );
@@ -2977,7 +2978,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetPsmSettings( CellularContext_t *
 
                 if( atCoreStatus != CELLULAR_AT_SUCCESS )
                 {
-                    LogInfo( ( "parseGetPsmToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_INT32" failed", pToken, tokenIndex ) );
+                    LogInfo( ( "parseGetPsmToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_UINT8" failed", pToken, tokenIndex ) );
                 }
 
                 tokenIndex++;

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -62,7 +62,7 @@
 /* Length of HPLMN including RAT. */
 #define CRSM_HPLMN_RAT_LENGTH               ( 9U )
 
-#define PRINTF_BINARY_PATTERN_INT4          "%"CELLULAR_LOG_FMT_CHAR"%"CELLULAR_LOG_FMT_CHAR"%"CELLULAR_LOG_FMT_CHAR"%"CELLULAR_LOG_FMT_CHAR""
+#define PRINTF_BINARY_PATTERN_INT4          "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR ""
 #define PRINTF_BYTE_TO_BINARY_INT4( i )          \
     ( ( ( ( i ) & 0x08U ) != 0U ) ? '1' : '0' ), \
     ( ( ( ( i ) & 0x04U ) != 0U ) ? '1' : '0' ), \
@@ -269,7 +269,7 @@ static CellularPktStatus_t _parseTimeZoneInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing TimeZone Information. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+            LogError( ( "Error in Processing TimeZone Information. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
         }
     }
 
@@ -298,7 +298,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing Year. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+            LogError( ( "Error in Processing Year. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -322,7 +322,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing month. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+                LogError( ( "Error in Processing month. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -346,7 +346,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing Day. token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+                LogError( ( "Error in Processing Day. token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -377,7 +377,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing Hour. token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+            LogError( ( "Error in Processing Hour. token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -400,7 +400,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing minute. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+                LogError( ( "Error in Processing minute. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -432,7 +432,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing Second. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
+                LogError( ( "Error in Processing Second. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -489,13 +489,13 @@ static CellularPktStatus_t _parseTimeZoneInfo( char * pTimeZoneResp,
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
-        LogDebug( ( "TimeZoneInfo: Timezone %"CELLULAR_LOG_FMT_INT32" Year %"CELLULAR_LOG_FMT_INT" Month %"CELLULAR_LOG_FMT_INT" day %"CELLULAR_LOG_FMT_INT",",
+        LogDebug( ( "TimeZoneInfo: Timezone %"CELLULAR_LOG_FMT_INT32 " Year %"CELLULAR_LOG_FMT_INT " Month %"CELLULAR_LOG_FMT_INT " day %"CELLULAR_LOG_FMT_INT ",",
                     pTimeInfo->timeZone,
                     pTimeInfo->year,
                     pTimeInfo->month,
                     pTimeInfo->day ) );
 
-        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT" Minute %"CELLULAR_LOG_FMT_INT" Second %"CELLULAR_LOG_FMT_INT"",
+        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT " Minute %"CELLULAR_LOG_FMT_INT " Second %"CELLULAR_LOG_FMT_INT "",
                     pTimeInfo->hour,
                     pTimeInfo->minute,
                     pTimeInfo->second ) );
@@ -844,7 +844,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetNetworkReg( CellularContext_t * 
             pCommandLine = pCommandLine->pNext;
         }
 
-        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT" pktStatus:%"CELLULAR_LOG_FMT_INT"", regType, pktStatus ) );
+        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT " pktStatus:%"CELLULAR_LOG_FMT_INT "", regType, pktStatus ) );
     }
 
     return pktStatus;
@@ -905,7 +905,7 @@ static bool _parseCopsRegModeToken( char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsRegMode: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+                LogError( ( "_parseCopsRegMode: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
                 parseStatus = false;
             }
         }
@@ -944,7 +944,7 @@ static bool _parseCopsNetworkNameFormatToken( const char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsNetworkNameFormat: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+                LogError( ( "_parseCopsNetworkNameFormat: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
                 parseStatus = false;
             }
         }
@@ -1031,7 +1031,7 @@ static bool _parseCopsRatToken( const char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsNetworkName: Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+                LogError( ( "_parseCopsNetworkName: Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
                 parseStatus = false;
             }
         }
@@ -1165,7 +1165,7 @@ static CellularPktStatus_t _Cellular_RecvFuncUpdateMccMnc( CellularContext_t * p
 
         if( atCoreStatus == CELLULAR_AT_ERROR )
         {
-            LogError( ( "ERROR: COPS %"CELLULAR_LOG_FMT_STR"", pCopsResponse ) );
+            LogError( ( "ERROR: COPS %"CELLULAR_LOG_FMT_STR "", pCopsResponse ) );
             pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
         }
     }
@@ -1211,7 +1211,7 @@ static CellularPktStatus_t _Cellular_RecvFuncIpAddress( CellularContext_t * pCon
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "Recv IP address: Context id: %"CELLULAR_LOG_FMT_STR", Address %"CELLULAR_LOG_FMT_STR"", pToken, pInputLine ) );
+            LogDebug( ( "Recv IP address: Context id: %"CELLULAR_LOG_FMT_STR ", Address %"CELLULAR_LOG_FMT_STR "", pToken, pInputLine ) );
 
             if( pInputLine[ 0 ] != '\0' )
             {
@@ -1254,7 +1254,7 @@ static CellularATError_t parseEidrxToken( char * pToken,
                 }
                 else
                 {
-                    LogError( ( "Error in processing RAT value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+                    LogError( ( "Error in processing RAT value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -1273,7 +1273,7 @@ static CellularATError_t parseEidrxToken( char * pToken,
                 }
                 else
                 {
-                    LogError( ( "Error in processing Requested Edrx value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+                    LogError( ( "Error in processing Requested Edrx value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -1320,7 +1320,7 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
         {
             if( parseEidrxToken( pToken, tokenIndex, pEidrxSettingsList, count ) != CELLULAR_AT_SUCCESS )
             {
-                LogInfo( ( "parseEidrxToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_INT" failed", pToken, tokenIndex ) );
+                LogInfo( ( "parseEidrxToken %"CELLULAR_LOG_FMT_STR " index %"CELLULAR_LOG_FMT_INT " failed", pToken, tokenIndex ) );
             }
 
             tokenIndex++;
@@ -1334,13 +1334,13 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
 
     if( atCoreStatus == CELLULAR_AT_SUCCESS )
     {
-        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT"]: RAT: %"CELLULAR_LOG_FMT_INT", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX"",
+        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT "]: RAT: %"CELLULAR_LOG_FMT_INT ", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX "",
                     count, pEidrxSettingsList->eidrxList[ count ].rat,
                     pEidrxSettingsList->eidrxList[ count ].requestedEdrxValue ) );
     }
     else
     {
-        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT"", atCoreStatus ) );
+        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT "", atCoreStatus ) );
     }
 
     return atCoreStatus;
@@ -1387,7 +1387,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetEidrxSettings( CellularContext_t
             if( ( strcmp( "+CEDRXS: 0", pInputLine ) == 0 ) ||
                 ( strcmp( "+CEDRXS:", pInputLine ) == 0 ) )
             {
-                LogDebug( ( "GetEidrx: empty EDRXS setting %"CELLULAR_LOG_FMT_STR"", pInputLine ) );
+                LogDebug( ( "GetEidrx: empty EDRXS setting %"CELLULAR_LOG_FMT_STR "", pInputLine ) );
             }
             else
             {
@@ -1502,7 +1502,7 @@ static CellularATError_t parseT3412TimerValue( char * pToken,
     {
         if( tempValue < 0 )
         {
-            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
         else
@@ -1572,7 +1572,7 @@ static CellularATError_t parseT3324TimerValue( char * pToken,
     {
         if( tempValue < 0 )
         {
-            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
         else
@@ -1695,12 +1695,12 @@ CellularError_t Cellular_CommonSetEidrxSettings( CellularHandle_t cellularHandle
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT",%"CELLULAR_LOG_FMT_INT",\"" PRINTF_BINARY_PATTERN_INT4 "\"",
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_INT ",%"CELLULAR_LOG_FMT_INT ",\"" PRINTF_BINARY_PATTERN_INT4 "\"",
                            "AT+CEDRXS=",
                            pEidrxSettings->mode,
                            pEidrxSettings->rat,
                            PRINTF_BYTE_TO_BINARY_INT4( pEidrxSettings->requestedEdrxValue ) );
-        LogDebug( ( "Eidrx setting: %"CELLULAR_LOG_FMT_STR" ", cmdBuf ) );
+        LogDebug( ( "Eidrx setting: %"CELLULAR_LOG_FMT_STR " ", cmdBuf ) );
         /* Query the PSMsettings from the network. */
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqSetEidrx );
 
@@ -1856,14 +1856,14 @@ CellularError_t Cellular_CommonGetServiceStatus( CellularHandle_t cellularHandle
         ( void ) strncpy( pServiceStatus->operatorName, operatorInfo.operatorName, CELLULAR_NETWORK_NAME_MAX_SIZE );
         pServiceStatus->operatorNameFormat = operatorInfo.operatorNameFormat;
 
-        LogDebug( ( "SrvStatus: rat %"CELLULAR_LOG_FMT_INT" cs %"CELLULAR_LOG_FMT_INT", ps %"CELLULAR_LOG_FMT_INT", mode %"CELLULAR_LOG_FMT_INT", csRejType %"CELLULAR_LOG_FMT_INT",",
+        LogDebug( ( "SrvStatus: rat %"CELLULAR_LOG_FMT_INT " cs %"CELLULAR_LOG_FMT_INT ", ps %"CELLULAR_LOG_FMT_INT ", mode %"CELLULAR_LOG_FMT_INT ", csRejType %"CELLULAR_LOG_FMT_INT ",",
                     pServiceStatus->rat,
                     pServiceStatus->csRegistrationStatus,
                     pServiceStatus->psRegistrationStatus,
                     pServiceStatus->networkRegistrationMode,
                     pServiceStatus->csRejectionType ) );
 
-        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT", psRejType %"CELLULAR_LOG_FMT_INT", psRej %"CELLULAR_LOG_FMT_INT", plmn %"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_STR"",
+        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT ", psRejType %"CELLULAR_LOG_FMT_INT ", psRej %"CELLULAR_LOG_FMT_INT ", plmn %"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_STR "",
                     pServiceStatus->csRejectionCause,
                     pServiceStatus->psRejectionType,
                     pServiceStatus->psRejectionCause,
@@ -1995,7 +1995,7 @@ CellularError_t Cellular_CommonGetModemInfo( CellularHandle_t cellularHandle,
         }
         else
         {
-            LogDebug( ( "ModemInfo: hwVer:%"CELLULAR_LOG_FMT_STR", fwVer:%"CELLULAR_LOG_FMT_STR", serialNum:%"CELLULAR_LOG_FMT_STR", IMEI:%"CELLULAR_LOG_FMT_STR", manufactureId:%"CELLULAR_LOG_FMT_STR", modelId:%"CELLULAR_LOG_FMT_STR" ",
+            LogDebug( ( "ModemInfo: hwVer:%"CELLULAR_LOG_FMT_STR ", fwVer:%"CELLULAR_LOG_FMT_STR ", serialNum:%"CELLULAR_LOG_FMT_STR ", IMEI:%"CELLULAR_LOG_FMT_STR ", manufactureId:%"CELLULAR_LOG_FMT_STR ", modelId:%"CELLULAR_LOG_FMT_STR " ",
                         pModemInfo->hardwareVersion, pModemInfo->firmwareVersion, pModemInfo->serialNumber, pModemInfo->imei,
                         pModemInfo->manufactureId, pModemInfo->modelId ) );
         }
@@ -2049,13 +2049,13 @@ CellularError_t Cellular_CommonGetIPAddress( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT"", "AT+CGPADDR=", contextId );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_INT "", "AT+CGPADDR=", contextId );
 
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetIp );
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR", pktStatus: %"CELLULAR_LOG_FMT_INT"", cmdBuf, pktStatus ) );
+            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR ", pktStatus: %"CELLULAR_LOG_FMT_INT "", cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2171,7 +2171,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
                 break;
 
             default:
-                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT"",
+                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT "",
                             CELLULAR_PDN_CONTEXT_IPV4V6 ) );
                 cellularStatus = CELLULAR_BAD_PARAMETER;
                 break;
@@ -2196,7 +2196,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT",\"%"CELLULAR_LOG_FMT_STR"\",\"%"CELLULAR_LOG_FMT_STR"\"",
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_INT ",\"%"CELLULAR_LOG_FMT_STR "\",\"%"CELLULAR_LOG_FMT_STR "\"",
                            "AT+CGDCONT=",
                            contextId,
                            pPdpTypeStr,
@@ -2205,7 +2205,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR", PktRet: %"CELLULAR_LOG_FMT_INT"", cmdBuf, pktStatus ) );
+            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR ", PktRet: %"CELLULAR_LOG_FMT_INT "", cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2275,7 +2275,7 @@ static CellularSimCardLockState_t _getSimLockState( char * pToken )
         }
         else
         {
-            LogError( ( "Unknown SIM Lock State %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogError( ( "Unknown SIM Lock State %"CELLULAR_LOG_FMT_STR "", pToken ) );
         }
     }
 
@@ -2331,7 +2331,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetSimLockStatus( CellularContext_t
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "SIM Lock State: %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogDebug( ( "SIM Lock State: %"CELLULAR_LOG_FMT_STR "", pToken ) );
             *pSimLockState = _getSimLockState( pToken );
         }
 
@@ -2413,7 +2413,7 @@ static bool _parseHplmn( char * pToken,
     }
     else if( ( strlen( pToken ) < ( CRSM_HPLMN_RAT_LENGTH ) ) || ( strncmp( pToken, "FFFFFF", 6 ) == 0 ) )
     {
-        LogError( ( "_parseHplmn: Error in processing HPLMN invalid token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+        LogError( ( "_parseHplmn: Error in processing HPLMN invalid token %"CELLULAR_LOG_FMT_STR "", pToken ) );
         parseStatus = false;
     }
     else
@@ -2686,7 +2686,7 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetSimLockStatus );
 
         cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
-        LogDebug( ( "_Cellular_GetSimStatus, Sim Insert State[%"CELLULAR_LOG_FMT_INT"], Lock State[%"CELLULAR_LOG_FMT_INT"]",
+        LogDebug( ( "_Cellular_GetSimStatus, Sim Insert State[%"CELLULAR_LOG_FMT_INT "], Lock State[%"CELLULAR_LOG_FMT_INT "]",
                     pSimCardStatus->simCardState, pSimCardStatus->simCardLockState ) );
     }
 
@@ -2759,7 +2759,7 @@ CellularError_t Cellular_CommonGetSimCardInfo( CellularHandle_t cellularHandle,
         }
         else
         {
-            LogDebug( ( "SimInfo updated: IMSI:%"CELLULAR_LOG_FMT_STR", Hplmn:%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_STR", ICCID:%"CELLULAR_LOG_FMT_STR"",
+            LogDebug( ( "SimInfo updated: IMSI:%"CELLULAR_LOG_FMT_STR ", Hplmn:%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_STR ", ICCID:%"CELLULAR_LOG_FMT_STR "",
                         pSimCardInfo->imsi, pSimCardInfo->plmn.mcc, pSimCardInfo->plmn.mnc,
                         pSimCardInfo->iccid ) );
         }
@@ -2782,7 +2782,7 @@ static uint32_t appendBinaryPattern( char * cmdBuf,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, cmdLen, "\"" PRINTF_BINARY_PATTERN_INT8 "\"%"CELLULAR_LOG_FMT_CHAR"",
+        ( void ) snprintf( cmdBuf, cmdLen, "\"" PRINTF_BINARY_PATTERN_INT8 "\"%"CELLULAR_LOG_FMT_CHAR "",
                            PRINTF_BYTE_TO_BINARY_INT8( value ), endOfString ? '\0' : ',' );
     }
     else
@@ -2790,7 +2790,7 @@ static uint32_t appendBinaryPattern( char * cmdBuf,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, cmdLen, "%"CELLULAR_LOG_FMT_CHAR"", endOfString ? '\0' : ',' );
+        ( void ) snprintf( cmdBuf, cmdLen, "%"CELLULAR_LOG_FMT_CHAR "", endOfString ? '\0' : ',' );
     }
 
     retLen = ( uint32_t ) strlen( cmdBuf );
@@ -2835,7 +2835,7 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%"CELLULAR_LOG_FMT_INT",", pPsmSettings->mode );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%"CELLULAR_LOG_FMT_INT ",", pPsmSettings->mode );
         cmdBufLen = ( uint32_t ) strlen( cmdBuf );
         cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicRauValue, false );
@@ -2846,7 +2846,7 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         ( void ) appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                       pPsmSettings->activeTimeValue, true );
 
-        LogDebug( ( "PSM setting: %"CELLULAR_LOG_FMT_STR" ", cmdBuf ) );
+        LogDebug( ( "PSM setting: %"CELLULAR_LOG_FMT_STR " ", cmdBuf ) );
 
         /* Query the PSMsettings from the network. */
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqSetPsm );
@@ -2877,7 +2877,7 @@ static CellularATError_t parseCpsmsMode( char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing mode. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogError( ( "Error in processing mode. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -2978,7 +2978,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetPsmSettings( CellularContext_t *
 
                 if( atCoreStatus != CELLULAR_AT_SUCCESS )
                 {
-                    LogInfo( ( "parseGetPsmToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_UINT8" failed", pToken, tokenIndex ) );
+                    LogInfo( ( "parseGetPsmToken %"CELLULAR_LOG_FMT_STR " index %"CELLULAR_LOG_FMT_UINT8 " failed", pToken, tokenIndex ) );
                 }
 
                 tokenIndex++;

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -62,7 +62,7 @@
 /* Length of HPLMN including RAT. */
 #define CRSM_HPLMN_RAT_LENGTH               ( 9U )
 
-#define PRINTF_BINARY_PATTERN_INT4          "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR ""
+#define PRINTF_BINARY_PATTERN_INT4          "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR "%"CELLULAR_LOG_FMT_CHAR
 #define PRINTF_BYTE_TO_BINARY_INT4( i )          \
     ( ( ( ( i ) & 0x08U ) != 0U ) ? '1' : '0' ), \
     ( ( ( ( i ) & 0x04U ) != 0U ) ? '1' : '0' ), \
@@ -269,7 +269,7 @@ static CellularPktStatus_t _parseTimeZoneInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing TimeZone Information. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+            LogError( ( "Error in Processing TimeZone Information. Token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
         }
     }
 
@@ -298,7 +298,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing Year. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+            LogError( ( "Error in Processing Year. Token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -322,7 +322,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing month. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+                LogError( ( "Error in Processing month. Token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -346,7 +346,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing Day. token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+                LogError( ( "Error in Processing Day. token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -377,7 +377,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing Hour. token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+            LogError( ( "Error in Processing Hour. token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -400,7 +400,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing minute. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+                LogError( ( "Error in Processing minute. Token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -432,7 +432,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing Second. Token %"CELLULAR_LOG_FMT_STR "", *ppToken ) );
+                LogError( ( "Error in Processing Second. Token %"CELLULAR_LOG_FMT_STR, *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -495,7 +495,7 @@ static CellularPktStatus_t _parseTimeZoneInfo( char * pTimeZoneResp,
                     pTimeInfo->month,
                     pTimeInfo->day ) );
 
-        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT " Minute %"CELLULAR_LOG_FMT_INT " Second %"CELLULAR_LOG_FMT_INT "",
+        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT " Minute %"CELLULAR_LOG_FMT_INT " Second %"CELLULAR_LOG_FMT_INT,
                     pTimeInfo->hour,
                     pTimeInfo->minute,
                     pTimeInfo->second ) );
@@ -844,7 +844,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetNetworkReg( CellularContext_t * 
             pCommandLine = pCommandLine->pNext;
         }
 
-        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT " pktStatus:%"CELLULAR_LOG_FMT_INT "", regType, pktStatus ) );
+        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT " pktStatus:%"CELLULAR_LOG_FMT_INT, regType, pktStatus ) );
     }
 
     return pktStatus;
@@ -905,7 +905,7 @@ static bool _parseCopsRegModeToken( char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsRegMode: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+                LogError( ( "_parseCopsRegMode: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
                 parseStatus = false;
             }
         }
@@ -944,7 +944,7 @@ static bool _parseCopsNetworkNameFormatToken( const char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsNetworkNameFormat: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+                LogError( ( "_parseCopsNetworkNameFormat: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
                 parseStatus = false;
             }
         }
@@ -1031,7 +1031,7 @@ static bool _parseCopsRatToken( const char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsNetworkName: Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+                LogError( ( "_parseCopsNetworkName: Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
                 parseStatus = false;
             }
         }
@@ -1165,7 +1165,7 @@ static CellularPktStatus_t _Cellular_RecvFuncUpdateMccMnc( CellularContext_t * p
 
         if( atCoreStatus == CELLULAR_AT_ERROR )
         {
-            LogError( ( "ERROR: COPS %"CELLULAR_LOG_FMT_STR "", pCopsResponse ) );
+            LogError( ( "ERROR: COPS %"CELLULAR_LOG_FMT_STR, pCopsResponse ) );
             pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
         }
     }
@@ -1211,7 +1211,7 @@ static CellularPktStatus_t _Cellular_RecvFuncIpAddress( CellularContext_t * pCon
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "Recv IP address: Context id: %"CELLULAR_LOG_FMT_STR ", Address %"CELLULAR_LOG_FMT_STR "", pToken, pInputLine ) );
+            LogDebug( ( "Recv IP address: Context id: %"CELLULAR_LOG_FMT_STR ", Address %"CELLULAR_LOG_FMT_STR, pToken, pInputLine ) );
 
             if( pInputLine[ 0 ] != '\0' )
             {
@@ -1254,7 +1254,7 @@ static CellularATError_t parseEidrxToken( char * pToken,
                 }
                 else
                 {
-                    LogError( ( "Error in processing RAT value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+                    LogError( ( "Error in processing RAT value. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -1273,7 +1273,7 @@ static CellularATError_t parseEidrxToken( char * pToken,
                 }
                 else
                 {
-                    LogError( ( "Error in processing Requested Edrx value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+                    LogError( ( "Error in processing Requested Edrx value. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -1334,13 +1334,13 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
 
     if( atCoreStatus == CELLULAR_AT_SUCCESS )
     {
-        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT "]: RAT: %"CELLULAR_LOG_FMT_INT ", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX "",
+        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT "]: RAT: %"CELLULAR_LOG_FMT_INT ", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX,
                     count, pEidrxSettingsList->eidrxList[ count ].rat,
                     pEidrxSettingsList->eidrxList[ count ].requestedEdrxValue ) );
     }
     else
     {
-        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT "", atCoreStatus ) );
+        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT, atCoreStatus ) );
     }
 
     return atCoreStatus;
@@ -1387,7 +1387,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetEidrxSettings( CellularContext_t
             if( ( strcmp( "+CEDRXS: 0", pInputLine ) == 0 ) ||
                 ( strcmp( "+CEDRXS:", pInputLine ) == 0 ) )
             {
-                LogDebug( ( "GetEidrx: empty EDRXS setting %"CELLULAR_LOG_FMT_STR "", pInputLine ) );
+                LogDebug( ( "GetEidrx: empty EDRXS setting %"CELLULAR_LOG_FMT_STR, pInputLine ) );
             }
             else
             {
@@ -1502,7 +1502,7 @@ static CellularATError_t parseT3412TimerValue( char * pToken,
     {
         if( tempValue < 0 )
         {
-            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
         else
@@ -1572,7 +1572,7 @@ static CellularATError_t parseT3324TimerValue( char * pToken,
     {
         if( tempValue < 0 )
         {
-            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
         else
@@ -1863,7 +1863,7 @@ CellularError_t Cellular_CommonGetServiceStatus( CellularHandle_t cellularHandle
                     pServiceStatus->networkRegistrationMode,
                     pServiceStatus->csRejectionType ) );
 
-        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT ", psRejType %"CELLULAR_LOG_FMT_INT ", psRej %"CELLULAR_LOG_FMT_INT ", plmn %"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_STR "",
+        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT ", psRejType %"CELLULAR_LOG_FMT_INT ", psRej %"CELLULAR_LOG_FMT_INT ", plmn %"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_STR,
                     pServiceStatus->csRejectionCause,
                     pServiceStatus->psRejectionType,
                     pServiceStatus->psRejectionCause,
@@ -2049,13 +2049,13 @@ CellularError_t Cellular_CommonGetIPAddress( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_INT "", "AT+CGPADDR=", contextId );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_INT, "AT+CGPADDR=", contextId );
 
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetIp );
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR ", pktStatus: %"CELLULAR_LOG_FMT_INT "", cmdBuf, pktStatus ) );
+            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR ", pktStatus: %"CELLULAR_LOG_FMT_INT, cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2171,7 +2171,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
                 break;
 
             default:
-                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT "",
+                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT,
                             CELLULAR_PDN_CONTEXT_IPV4V6 ) );
                 cellularStatus = CELLULAR_BAD_PARAMETER;
                 break;
@@ -2205,7 +2205,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR ", PktRet: %"CELLULAR_LOG_FMT_INT "", cmdBuf, pktStatus ) );
+            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR ", PktRet: %"CELLULAR_LOG_FMT_INT, cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2275,7 +2275,7 @@ static CellularSimCardLockState_t _getSimLockState( char * pToken )
         }
         else
         {
-            LogError( ( "Unknown SIM Lock State %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogError( ( "Unknown SIM Lock State %"CELLULAR_LOG_FMT_STR, pToken ) );
         }
     }
 
@@ -2331,7 +2331,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetSimLockStatus( CellularContext_t
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "SIM Lock State: %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogDebug( ( "SIM Lock State: %"CELLULAR_LOG_FMT_STR, pToken ) );
             *pSimLockState = _getSimLockState( pToken );
         }
 
@@ -2413,7 +2413,7 @@ static bool _parseHplmn( char * pToken,
     }
     else if( ( strlen( pToken ) < ( CRSM_HPLMN_RAT_LENGTH ) ) || ( strncmp( pToken, "FFFFFF", 6 ) == 0 ) )
     {
-        LogError( ( "_parseHplmn: Error in processing HPLMN invalid token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+        LogError( ( "_parseHplmn: Error in processing HPLMN invalid token %"CELLULAR_LOG_FMT_STR, pToken ) );
         parseStatus = false;
     }
     else
@@ -2759,7 +2759,7 @@ CellularError_t Cellular_CommonGetSimCardInfo( CellularHandle_t cellularHandle,
         }
         else
         {
-            LogDebug( ( "SimInfo updated: IMSI:%"CELLULAR_LOG_FMT_STR ", Hplmn:%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_STR ", ICCID:%"CELLULAR_LOG_FMT_STR "",
+            LogDebug( ( "SimInfo updated: IMSI:%"CELLULAR_LOG_FMT_STR ", Hplmn:%"CELLULAR_LOG_FMT_STR "%"CELLULAR_LOG_FMT_STR ", ICCID:%"CELLULAR_LOG_FMT_STR,
                         pSimCardInfo->imsi, pSimCardInfo->plmn.mcc, pSimCardInfo->plmn.mnc,
                         pSimCardInfo->iccid ) );
         }
@@ -2782,7 +2782,7 @@ static uint32_t appendBinaryPattern( char * cmdBuf,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, cmdLen, "\"" PRINTF_BINARY_PATTERN_INT8 "\"%"CELLULAR_LOG_FMT_CHAR "",
+        ( void ) snprintf( cmdBuf, cmdLen, "\"" PRINTF_BINARY_PATTERN_INT8 "\"%"CELLULAR_LOG_FMT_CHAR,
                            PRINTF_BYTE_TO_BINARY_INT8( value ), endOfString ? '\0' : ',' );
     }
     else
@@ -2790,7 +2790,7 @@ static uint32_t appendBinaryPattern( char * cmdBuf,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, cmdLen, "%"CELLULAR_LOG_FMT_CHAR "", endOfString ? '\0' : ',' );
+        ( void ) snprintf( cmdBuf, cmdLen, "%"CELLULAR_LOG_FMT_CHAR, endOfString ? '\0' : ',' );
     }
 
     retLen = ( uint32_t ) strlen( cmdBuf );
@@ -2877,7 +2877,7 @@ static CellularATError_t parseCpsmsMode( char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing mode. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogError( ( "Error in processing mode. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -62,7 +62,7 @@
 /* Length of HPLMN including RAT. */
 #define CRSM_HPLMN_RAT_LENGTH               ( 9U )
 
-#define PRINTF_BINARY_PATTERN_INT4          "%c%c%c%c"
+#define PRINTF_BINARY_PATTERN_INT4          "%"CELLULAR_LOG_FMT_CHAR"%"CELLULAR_LOG_FMT_CHAR"%"CELLULAR_LOG_FMT_CHAR"%"CELLULAR_LOG_FMT_CHAR""
 #define PRINTF_BYTE_TO_BINARY_INT4( i )          \
     ( ( ( ( i ) & 0x08U ) != 0U ) ? '1' : '0' ), \
     ( ( ( ( i ) & 0x04U ) != 0U ) ? '1' : '0' ), \
@@ -269,7 +269,7 @@ static CellularPktStatus_t _parseTimeZoneInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing TimeZone Information. Token %s", *ppToken ) );
+            LogError( ( "Error in Processing TimeZone Information. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
         }
     }
 
@@ -298,7 +298,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing Year. Token %s", *ppToken ) );
+            LogError( ( "Error in Processing Year. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -322,7 +322,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing month. Token %s", *ppToken ) );
+                LogError( ( "Error in Processing month. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -346,7 +346,7 @@ static CellularPktStatus_t _parseYearMonthDayInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing Day. token %s", *ppToken ) );
+                LogError( ( "Error in Processing Day. token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -377,7 +377,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
         }
         else
         {
-            LogError( ( "Error in Processing Hour. token %s", *ppToken ) );
+            LogError( ( "Error in Processing Hour. token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -400,7 +400,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing minute. Token %s", *ppToken ) );
+                LogError( ( "Error in Processing minute. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -432,7 +432,7 @@ static CellularPktStatus_t _parseTimeInCCLKResponse( char ** ppToken,
             }
             else
             {
-                LogError( ( "Error in Processing Second. Token %s", *ppToken ) );
+                LogError( ( "Error in Processing Second. Token %"CELLULAR_LOG_FMT_STR"", *ppToken ) );
                 atCoreStatus = CELLULAR_AT_ERROR;
             }
         }
@@ -489,12 +489,12 @@ static CellularPktStatus_t _parseTimeZoneInfo( char * pTimeZoneResp,
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
-        LogDebug( ( "TimeZoneInfo: Timezone %d Year %d Month %d day %d,", pTimeInfo->timeZone,
+        LogDebug( ( "TimeZoneInfo: Timezone %"CELLULAR_LOG_FMT_INT32" Year %"CELLULAR_LOG_FMT_INT32" Month %"CELLULAR_LOG_FMT_INT32" day %"CELLULAR_LOG_FMT_INT32",", pTimeInfo->timeZone,
                     pTimeInfo->year,
                     pTimeInfo->month,
                     pTimeInfo->day ) );
 
-        LogDebug( ( "Hour %d Minute %d Second %d",
+        LogDebug( ( "Hour %"CELLULAR_LOG_FMT_INT32" Minute %"CELLULAR_LOG_FMT_INT32" Second %"CELLULAR_LOG_FMT_INT32"",
                     pTimeInfo->hour,
                     pTimeInfo->minute,
                     pTimeInfo->second ) );
@@ -843,7 +843,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetNetworkReg( CellularContext_t * 
             pCommandLine = pCommandLine->pNext;
         }
 
-        LogDebug( ( "atcmd network register status %d pktStatus:%d", regType, pktStatus ) );
+        LogDebug( ( "atcmd network register status %"CELLULAR_LOG_FMT_INT32" pktStatus:%"CELLULAR_LOG_FMT_INT32"", regType, pktStatus ) );
     }
 
     return pktStatus;
@@ -904,7 +904,7 @@ static bool _parseCopsRegModeToken( char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsRegMode: Error in processing Network Registration mode. Token %s", pToken ) );
+                LogError( ( "_parseCopsRegMode: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
                 parseStatus = false;
             }
         }
@@ -943,7 +943,7 @@ static bool _parseCopsNetworkNameFormatToken( const char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsNetworkNameFormat: Error in processing Network Registration mode. Token %s", pToken ) );
+                LogError( ( "_parseCopsNetworkNameFormat: Error in processing Network Registration mode. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
                 parseStatus = false;
             }
         }
@@ -1030,7 +1030,7 @@ static bool _parseCopsRatToken( const char * pToken,
             }
             else
             {
-                LogError( ( "_parseCopsNetworkName: Error in processing RAT. Token %s", pToken ) );
+                LogError( ( "_parseCopsNetworkName: Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
                 parseStatus = false;
             }
         }
@@ -1164,7 +1164,7 @@ static CellularPktStatus_t _Cellular_RecvFuncUpdateMccMnc( CellularContext_t * p
 
         if( atCoreStatus == CELLULAR_AT_ERROR )
         {
-            LogError( ( "ERROR: COPS %s", pCopsResponse ) );
+            LogError( ( "ERROR: COPS %"CELLULAR_LOG_FMT_STR"", pCopsResponse ) );
             pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
         }
     }
@@ -1210,7 +1210,7 @@ static CellularPktStatus_t _Cellular_RecvFuncIpAddress( CellularContext_t * pCon
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "Recv IP address: Context id: %s, Address %s", pToken, pInputLine ) );
+            LogDebug( ( "Recv IP address: Context id: %"CELLULAR_LOG_FMT_STR", Address %"CELLULAR_LOG_FMT_STR"", pToken, pInputLine ) );
 
             if( pInputLine[ 0 ] != '\0' )
             {
@@ -1253,7 +1253,7 @@ static CellularATError_t parseEidrxToken( char * pToken,
                 }
                 else
                 {
-                    LogError( ( "Error in processing RAT value. Token %s", pToken ) );
+                    LogError( ( "Error in processing RAT value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -1272,7 +1272,7 @@ static CellularATError_t parseEidrxToken( char * pToken,
                 }
                 else
                 {
-                    LogError( ( "Error in processing Requested Edrx value. Token %s", pToken ) );
+                    LogError( ( "Error in processing Requested Edrx value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -1319,7 +1319,7 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
         {
             if( parseEidrxToken( pToken, tokenIndex, pEidrxSettingsList, count ) != CELLULAR_AT_SUCCESS )
             {
-                LogInfo( ( "parseEidrxToken %s index %d failed", pToken, tokenIndex ) );
+                LogInfo( ( "parseEidrxToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_INT32" failed", pToken, tokenIndex ) );
             }
 
             tokenIndex++;
@@ -1333,13 +1333,13 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
 
     if( atCoreStatus == CELLULAR_AT_SUCCESS )
     {
-        LogDebug( ( "GetEidrx setting[%d]: RAT: %d, Value: 0x%x",
+        LogDebug( ( "GetEidrx setting[%"CELLULAR_LOG_FMT_INT32"]: RAT: %"CELLULAR_LOG_FMT_INT32", Value: 0x%"CELLULAR_LOG_FMT_UINT32_HEX"",
                     count, pEidrxSettingsList->eidrxList[ count ].rat,
                     pEidrxSettingsList->eidrxList[ count ].requestedEdrxValue ) );
     }
     else
     {
-        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %d", atCoreStatus ) );
+        LogError( ( "GetEidrx: Parsing Error encountered, atCoreStatus: %"CELLULAR_LOG_FMT_INT32"", atCoreStatus ) );
     }
 
     return atCoreStatus;
@@ -1386,7 +1386,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetEidrxSettings( CellularContext_t
             if( ( strcmp( "+CEDRXS: 0", pInputLine ) == 0 ) ||
                 ( strcmp( "+CEDRXS:", pInputLine ) == 0 ) )
             {
-                LogDebug( ( "GetEidrx: empty EDRXS setting %s", pInputLine ) );
+                LogDebug( ( "GetEidrx: empty EDRXS setting %"CELLULAR_LOG_FMT_STR"", pInputLine ) );
             }
             else
             {
@@ -1501,7 +1501,7 @@ static CellularATError_t parseT3412TimerValue( char * pToken,
     {
         if( tempValue < 0 )
         {
-            LogError( ( "Error in processing Periodic Processing Active time value. Token %s", pToken ) );
+            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
         else
@@ -1571,7 +1571,7 @@ static CellularATError_t parseT3324TimerValue( char * pToken,
     {
         if( tempValue < 0 )
         {
-            LogError( ( "Error in processing Periodic Processing Active time value. Token %s", pToken ) );
+            LogError( ( "Error in processing Periodic Processing Active time value. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
         else
@@ -1694,12 +1694,12 @@ CellularError_t Cellular_CommonSetEidrxSettings( CellularHandle_t cellularHandle
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%s%d,%d,\"" PRINTF_BINARY_PATTERN_INT4 "\"",
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT32",%"CELLULAR_LOG_FMT_INT32",\"" PRINTF_BINARY_PATTERN_INT4 "\"",
                            "AT+CEDRXS=",
                            pEidrxSettings->mode,
                            pEidrxSettings->rat,
                            PRINTF_BYTE_TO_BINARY_INT4( pEidrxSettings->requestedEdrxValue ) );
-        LogDebug( ( "Eidrx setting: %s ", cmdBuf ) );
+        LogDebug( ( "Eidrx setting: %"CELLULAR_LOG_FMT_STR" ", cmdBuf ) );
         /* Query the PSMsettings from the network. */
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqSetEidrx );
 
@@ -1855,14 +1855,14 @@ CellularError_t Cellular_CommonGetServiceStatus( CellularHandle_t cellularHandle
         ( void ) strncpy( pServiceStatus->operatorName, operatorInfo.operatorName, CELLULAR_NETWORK_NAME_MAX_SIZE );
         pServiceStatus->operatorNameFormat = operatorInfo.operatorNameFormat;
 
-        LogDebug( ( "SrvStatus: rat %d cs %d, ps %d, mode %d, csRejType %d,",
+        LogDebug( ( "SrvStatus: rat %"CELLULAR_LOG_FMT_INT32" cs %"CELLULAR_LOG_FMT_INT32", ps %"CELLULAR_LOG_FMT_INT32", mode %"CELLULAR_LOG_FMT_INT32", csRejType %"CELLULAR_LOG_FMT_INT32",",
                     pServiceStatus->rat,
                     pServiceStatus->csRegistrationStatus,
                     pServiceStatus->psRegistrationStatus,
                     pServiceStatus->networkRegistrationMode,
                     pServiceStatus->csRejectionType ) );
 
-        LogDebug( ( "csRej %d, psRejType %d, psRej %d, plmn %s%s",
+        LogDebug( ( "csRej %"CELLULAR_LOG_FMT_INT32", psRejType %"CELLULAR_LOG_FMT_INT32", psRej %"CELLULAR_LOG_FMT_INT32", plmn %"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_STR"",
                     pServiceStatus->csRejectionCause,
                     pServiceStatus->psRejectionType,
                     pServiceStatus->psRejectionCause,
@@ -1994,7 +1994,7 @@ CellularError_t Cellular_CommonGetModemInfo( CellularHandle_t cellularHandle,
         }
         else
         {
-            LogDebug( ( "ModemInfo: hwVer:%s, fwVer:%s, serialNum:%s, IMEI:%s, manufactureId:%s, modelId:%s ",
+            LogDebug( ( "ModemInfo: hwVer:%"CELLULAR_LOG_FMT_STR", fwVer:%"CELLULAR_LOG_FMT_STR", serialNum:%"CELLULAR_LOG_FMT_STR", IMEI:%"CELLULAR_LOG_FMT_STR", manufactureId:%"CELLULAR_LOG_FMT_STR", modelId:%"CELLULAR_LOG_FMT_STR" ",
                         pModemInfo->hardwareVersion, pModemInfo->firmwareVersion, pModemInfo->serialNumber, pModemInfo->imei,
                         pModemInfo->manufactureId, pModemInfo->modelId ) );
         }
@@ -2048,13 +2048,13 @@ CellularError_t Cellular_CommonGetIPAddress( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%s%d", "AT+CGPADDR=", contextId );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT32"", "AT+CGPADDR=", contextId );
 
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetIp );
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%s, pktStatus: %d", cmdBuf, pktStatus ) );
+            LogError( ( "_Cellular_GetIPAddress: couldn't retrieve the IP, cmdBuf:%"CELLULAR_LOG_FMT_STR", pktStatus: %"CELLULAR_LOG_FMT_INT32"", cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2170,7 +2170,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
                 break;
 
             default:
-                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %d",
+                LogError( ( "Cellular_CommonSetPdnConfig: Invalid pdn context type %"CELLULAR_LOG_FMT_INT32"",
                             CELLULAR_PDN_CONTEXT_IPV4V6 ) );
                 cellularStatus = CELLULAR_BAD_PARAMETER;
                 break;
@@ -2195,7 +2195,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%s%d,\"%s\",\"%s\"",
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_INT32",\"%"CELLULAR_LOG_FMT_STR"\",\"%"CELLULAR_LOG_FMT_STR"\"",
                            "AT+CGDCONT=",
                            contextId,
                            pPdpTypeStr,
@@ -2204,7 +2204,7 @@ CellularError_t Cellular_CommonSetPdnConfig( CellularHandle_t cellularHandle,
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%s, PktRet: %d", cmdBuf, pktStatus ) );
+            LogError( ( "Cellular_CommonSetPdnConfig: can't set PDN, cmdBuf:%"CELLULAR_LOG_FMT_STR", PktRet: %"CELLULAR_LOG_FMT_INT32"", cmdBuf, pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2274,7 +2274,7 @@ static CellularSimCardLockState_t _getSimLockState( char * pToken )
         }
         else
         {
-            LogError( ( "Unknown SIM Lock State %s", pToken ) );
+            LogError( ( "Unknown SIM Lock State %"CELLULAR_LOG_FMT_STR"", pToken ) );
         }
     }
 
@@ -2330,7 +2330,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetSimLockStatus( CellularContext_t
 
         if( atCoreStatus == CELLULAR_AT_SUCCESS )
         {
-            LogDebug( ( "SIM Lock State: %s", pToken ) );
+            LogDebug( ( "SIM Lock State: %"CELLULAR_LOG_FMT_STR"", pToken ) );
             *pSimLockState = _getSimLockState( pToken );
         }
 
@@ -2412,7 +2412,7 @@ static bool _parseHplmn( char * pToken,
     }
     else if( ( strlen( pToken ) < ( CRSM_HPLMN_RAT_LENGTH ) ) || ( strncmp( pToken, "FFFFFF", 6 ) == 0 ) )
     {
-        LogError( ( "_parseHplmn: Error in processing HPLMN invalid token %s", pToken ) );
+        LogError( ( "_parseHplmn: Error in processing HPLMN invalid token %"CELLULAR_LOG_FMT_STR"", pToken ) );
         parseStatus = false;
     }
     else
@@ -2685,7 +2685,7 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetSimLockStatus );
 
         cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
-        LogDebug( ( "_Cellular_GetSimStatus, Sim Insert State[%d], Lock State[%d]",
+        LogDebug( ( "_Cellular_GetSimStatus, Sim Insert State[%"CELLULAR_LOG_FMT_INT32"], Lock State[%"CELLULAR_LOG_FMT_INT32"]",
                     pSimCardStatus->simCardState, pSimCardStatus->simCardLockState ) );
     }
 
@@ -2758,7 +2758,7 @@ CellularError_t Cellular_CommonGetSimCardInfo( CellularHandle_t cellularHandle,
         }
         else
         {
-            LogDebug( ( "SimInfo updated: IMSI:%s, Hplmn:%s%s, ICCID:%s",
+            LogDebug( ( "SimInfo updated: IMSI:%"CELLULAR_LOG_FMT_STR", Hplmn:%"CELLULAR_LOG_FMT_STR"%"CELLULAR_LOG_FMT_STR", ICCID:%"CELLULAR_LOG_FMT_STR"",
                         pSimCardInfo->imsi, pSimCardInfo->plmn.mcc, pSimCardInfo->plmn.mnc,
                         pSimCardInfo->iccid ) );
         }
@@ -2781,7 +2781,7 @@ static uint32_t appendBinaryPattern( char * cmdBuf,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, cmdLen, "\"" PRINTF_BINARY_PATTERN_INT8 "\"%c",
+        ( void ) snprintf( cmdBuf, cmdLen, "\"" PRINTF_BINARY_PATTERN_INT8 "\"%"CELLULAR_LOG_FMT_CHAR"",
                            PRINTF_BYTE_TO_BINARY_INT8( value ), endOfString ? '\0' : ',' );
     }
     else
@@ -2789,7 +2789,7 @@ static uint32_t appendBinaryPattern( char * cmdBuf,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, cmdLen, "%c", endOfString ? '\0' : ',' );
+        ( void ) snprintf( cmdBuf, cmdLen, "%"CELLULAR_LOG_FMT_CHAR"", endOfString ? '\0' : ',' );
     }
 
     retLen = ( uint32_t ) strlen( cmdBuf );
@@ -2834,7 +2834,7 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         /* MISRA Ref 21.6.1 [Use of snprintf] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%d,", pPsmSettings->mode );
+        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%"CELLULAR_LOG_FMT_INT32",", pPsmSettings->mode );
         cmdBufLen = ( uint32_t ) strlen( cmdBuf );
         cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicRauValue, false );
@@ -2845,7 +2845,7 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         ( void ) appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                       pPsmSettings->activeTimeValue, true );
 
-        LogDebug( ( "PSM setting: %s ", cmdBuf ) );
+        LogDebug( ( "PSM setting: %"CELLULAR_LOG_FMT_STR" ", cmdBuf ) );
 
         /* Query the PSMsettings from the network. */
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqSetPsm );
@@ -2876,7 +2876,7 @@ static CellularATError_t parseCpsmsMode( char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing mode. Token %s", pToken ) );
+            LogError( ( "Error in processing mode. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -2977,7 +2977,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetPsmSettings( CellularContext_t *
 
                 if( atCoreStatus != CELLULAR_AT_SUCCESS )
                 {
-                    LogInfo( ( "parseGetPsmToken %s index %d failed", pToken, tokenIndex ) );
+                    LogInfo( ( "parseGetPsmToken %"CELLULAR_LOG_FMT_STR" index %"CELLULAR_LOG_FMT_INT32" failed", pToken, tokenIndex ) );
                 }
 
                 tokenIndex++;

--- a/source/cellular_3gpp_urc_handler.c
+++ b/source/cellular_3gpp_urc_handler.c
@@ -230,7 +230,7 @@ static CellularPktStatus_t _parseCellIdInRegStatus( const char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing Cell Id. Token %s", pToken ) );
+            LogError( ( "Error in processing Cell Id. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -255,7 +255,7 @@ static CellularPktStatus_t _parseRatInfoInRegStatus( const char * pToken,
         if( var >= ( int32_t ) CELLULAR_RAT_MAX )
         {
             atCoreStatus = CELLULAR_AT_ERROR;
-            LogError( ( "Error in processing RAT. Token %s", pToken ) );
+            LogError( ( "Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
         }
         else if( ( var == ( int32_t ) CELLULAR_RAT_GSM ) || ( var == ( int32_t ) CELLULAR_RAT_EDGE ) ||
                  ( var == ( int32_t ) CELLULAR_RAT_CATM1 ) || ( var == ( int32_t ) CELLULAR_RAT_NBIOT ) )
@@ -442,15 +442,15 @@ static void _regStatusGenerateLog( char * pRegPayload,
 
     if( regType == CELLULAR_REG_TYPE_CREG )
     {
-        LogDebug( ( "URC: CREG: %s", pRegPayload ) );
+        LogDebug( ( "URC: CREG: %"CELLULAR_LOG_FMT_STR"", pRegPayload ) );
     }
     else if( regType == CELLULAR_REG_TYPE_CGREG )
     {
-        LogDebug( ( "URC: CGREG: %s", pRegPayload ) );
+        LogDebug( ( "URC: CGREG: %"CELLULAR_LOG_FMT_STR"", pRegPayload ) );
     }
     else if( regType == CELLULAR_REG_TYPE_CEREG )
     {
-        LogDebug( ( "URC: CEREG: %s", pRegPayload ) );
+        LogDebug( ( "URC: CEREG: %"CELLULAR_LOG_FMT_STR"", pRegPayload ) );
     }
     else
     {

--- a/source/cellular_3gpp_urc_handler.c
+++ b/source/cellular_3gpp_urc_handler.c
@@ -230,7 +230,7 @@ static CellularPktStatus_t _parseCellIdInRegStatus( const char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing Cell Id. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogError( ( "Error in processing Cell Id. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -255,7 +255,7 @@ static CellularPktStatus_t _parseRatInfoInRegStatus( const char * pToken,
         if( var >= ( int32_t ) CELLULAR_RAT_MAX )
         {
             atCoreStatus = CELLULAR_AT_ERROR;
-            LogError( ( "Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
+            LogError( ( "Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR, pToken ) );
         }
         else if( ( var == ( int32_t ) CELLULAR_RAT_GSM ) || ( var == ( int32_t ) CELLULAR_RAT_EDGE ) ||
                  ( var == ( int32_t ) CELLULAR_RAT_CATM1 ) || ( var == ( int32_t ) CELLULAR_RAT_NBIOT ) )
@@ -442,15 +442,15 @@ static void _regStatusGenerateLog( char * pRegPayload,
 
     if( regType == CELLULAR_REG_TYPE_CREG )
     {
-        LogDebug( ( "URC: CREG: %"CELLULAR_LOG_FMT_STR "", pRegPayload ) );
+        LogDebug( ( "URC: CREG: %"CELLULAR_LOG_FMT_STR, pRegPayload ) );
     }
     else if( regType == CELLULAR_REG_TYPE_CGREG )
     {
-        LogDebug( ( "URC: CGREG: %"CELLULAR_LOG_FMT_STR "", pRegPayload ) );
+        LogDebug( ( "URC: CGREG: %"CELLULAR_LOG_FMT_STR, pRegPayload ) );
     }
     else if( regType == CELLULAR_REG_TYPE_CEREG )
     {
-        LogDebug( ( "URC: CEREG: %"CELLULAR_LOG_FMT_STR "", pRegPayload ) );
+        LogDebug( ( "URC: CEREG: %"CELLULAR_LOG_FMT_STR, pRegPayload ) );
     }
     else
     {

--- a/source/cellular_3gpp_urc_handler.c
+++ b/source/cellular_3gpp_urc_handler.c
@@ -230,7 +230,7 @@ static CellularPktStatus_t _parseCellIdInRegStatus( const char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing Cell Id. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogError( ( "Error in processing Cell Id. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -255,7 +255,7 @@ static CellularPktStatus_t _parseRatInfoInRegStatus( const char * pToken,
         if( var >= ( int32_t ) CELLULAR_RAT_MAX )
         {
             atCoreStatus = CELLULAR_AT_ERROR;
-            LogError( ( "Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR"", pToken ) );
+            LogError( ( "Error in processing RAT. Token %"CELLULAR_LOG_FMT_STR "", pToken ) );
         }
         else if( ( var == ( int32_t ) CELLULAR_RAT_GSM ) || ( var == ( int32_t ) CELLULAR_RAT_EDGE ) ||
                  ( var == ( int32_t ) CELLULAR_RAT_CATM1 ) || ( var == ( int32_t ) CELLULAR_RAT_NBIOT ) )
@@ -442,15 +442,15 @@ static void _regStatusGenerateLog( char * pRegPayload,
 
     if( regType == CELLULAR_REG_TYPE_CREG )
     {
-        LogDebug( ( "URC: CREG: %"CELLULAR_LOG_FMT_STR"", pRegPayload ) );
+        LogDebug( ( "URC: CREG: %"CELLULAR_LOG_FMT_STR "", pRegPayload ) );
     }
     else if( regType == CELLULAR_REG_TYPE_CGREG )
     {
-        LogDebug( ( "URC: CGREG: %"CELLULAR_LOG_FMT_STR"", pRegPayload ) );
+        LogDebug( ( "URC: CGREG: %"CELLULAR_LOG_FMT_STR "", pRegPayload ) );
     }
     else if( regType == CELLULAR_REG_TYPE_CEREG )
     {
-        LogDebug( ( "URC: CEREG: %"CELLULAR_LOG_FMT_STR"", pRegPayload ) );
+        LogDebug( ( "URC: CEREG: %"CELLULAR_LOG_FMT_STR "", pRegPayload ) );
     }
     else
     {

--- a/source/cellular_at_core.c
+++ b/source/cellular_at_core.c
@@ -661,7 +661,7 @@ CellularATError_t Cellular_ATHexStrToHex( const char * pString,
             }
             else
             {
-                firstNibble = ( uint8_t )( firstNibble << 4 );
+                firstNibble = ( uint8_t ) ( firstNibble << 4 );
                 ( pHexData )[ i ] = firstNibble | secondNibble;
             }
 

--- a/source/cellular_at_core.c
+++ b/source/cellular_at_core.c
@@ -661,7 +661,7 @@ CellularATError_t Cellular_ATHexStrToHex( const char * pString,
             }
             else
             {
-                firstNibble = firstNibble << 4;
+                firstNibble = ( uint8_t )( firstNibble << 4 );
                 ( pHexData )[ i ] = firstNibble | secondNibble;
             }
 

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -102,13 +102,13 @@ static void _Cellular_SetShutdownCallback( CellularContext_t * pContext,
 /*-----------------------------------------------------------*/
 
 #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 1 )
-    static CellularContext_t cellularStaticContextTable[ CELLULAR_CONTEXT_MAX ] = { 0 };
+static CellularContext_t cellularStaticContextTable[ CELLULAR_CONTEXT_MAX ] = { 0 };
 #endif
 
 static CellularContext_t * cellularContextTable[ CELLULAR_CONTEXT_MAX ] = { 0 };
 
 #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 1 )
-    static CellularSocketContext_t cellularStaticSocketDataTable[ CELLULAR_NUM_SOCKET_MAX ] = { 0 };
+static CellularSocketContext_t cellularStaticSocketDataTable[ CELLULAR_NUM_SOCKET_MAX ] = { 0 };
 #endif
 
 /*-----------------------------------------------------------*/
@@ -125,13 +125,13 @@ static CellularContext_t * _Cellular_AllocContext( void )
         if( cellularContextTable[ i ] == NULL )
         {
             #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 1 )
-                {
-                    pContext = &cellularStaticContextTable[ i ];
-                }
+            {
+                pContext = &cellularStaticContextTable[ i ];
+            }
             #else
-                {
-                    pContext = ( CellularContext_t * ) Platform_Malloc( sizeof( CellularContext_t ) );
-                }
+            {
+                pContext = ( CellularContext_t * ) Platform_Malloc( sizeof( CellularContext_t ) );
+            }
             #endif
 
             if( pContext != NULL )
@@ -163,9 +163,9 @@ static void _Cellular_FreeContext( CellularContext_t * pContext )
         {
             cellularContextTable[ i ] = NULL;
             #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 0 )
-                {
-                    Platform_Free( pContext );
-                }
+            {
+                Platform_Free( pContext );
+            }
             #endif
             break;
         }
@@ -262,9 +262,9 @@ static void libClose( CellularContext_t * pContext )
         if( pContext->pSocketData[ i ] != NULL )
         {
             #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 0 )
-                {
-                    Platform_Free( pContext->pSocketData[ i ] );
-                }
+            {
+                Platform_Free( pContext->pSocketData[ i ] );
+            }
             #endif
             pContext->pSocketData[ i ] = NULL;
         }
@@ -545,13 +545,13 @@ CellularError_t _Cellular_CreateSocketData( CellularContext_t * pContext,
         if( pContext->pSocketData[ socketId ] == NULL )
         {
             #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 1 )
-                {
-                    pSocketData = &cellularStaticSocketDataTable[ socketId ];
-                }
+            {
+                pSocketData = &cellularStaticSocketDataTable[ socketId ];
+            }
             #else
-                {
-                    pSocketData = ( CellularSocketContext_t * ) Platform_Malloc( sizeof( CellularSocketContext_t ) );
-                }
+            {
+                pSocketData = ( CellularSocketContext_t * ) Platform_Malloc( sizeof( CellularSocketContext_t ) );
+            }
             #endif
 
             if( pSocketData != NULL )

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -102,13 +102,13 @@ static void _Cellular_SetShutdownCallback( CellularContext_t * pContext,
 /*-----------------------------------------------------------*/
 
 #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 1 )
-static CellularContext_t cellularStaticContextTable[ CELLULAR_CONTEXT_MAX ] = { 0 };
+    static CellularContext_t cellularStaticContextTable[ CELLULAR_CONTEXT_MAX ] = { 0 };
 #endif
 
 static CellularContext_t * cellularContextTable[ CELLULAR_CONTEXT_MAX ] = { 0 };
 
 #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 1 )
-static CellularSocketContext_t cellularStaticSocketDataTable[ CELLULAR_NUM_SOCKET_MAX ] = { 0 };
+    static CellularSocketContext_t cellularStaticSocketDataTable[ CELLULAR_NUM_SOCKET_MAX ] = { 0 };
 #endif
 
 /*-----------------------------------------------------------*/
@@ -125,13 +125,13 @@ static CellularContext_t * _Cellular_AllocContext( void )
         if( cellularContextTable[ i ] == NULL )
         {
             #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 1 )
-            {
-                pContext = &cellularStaticContextTable[ i ];
-            }
+                {
+                    pContext = &cellularStaticContextTable[ i ];
+                }
             #else
-            {
-                pContext = ( CellularContext_t * ) Platform_Malloc( sizeof( CellularContext_t ) );
-            }
+                {
+                    pContext = ( CellularContext_t * ) Platform_Malloc( sizeof( CellularContext_t ) );
+                }
             #endif
 
             if( pContext != NULL )
@@ -163,9 +163,9 @@ static void _Cellular_FreeContext( CellularContext_t * pContext )
         {
             cellularContextTable[ i ] = NULL;
             #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 0 )
-            {
-                Platform_Free( pContext );
-            }
+                {
+                    Platform_Free( pContext );
+                }
             #endif
             break;
         }
@@ -262,9 +262,9 @@ static void libClose( CellularContext_t * pContext )
         if( pContext->pSocketData[ i ] != NULL )
         {
             #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 0 )
-            {
-                Platform_Free( pContext->pSocketData[ i ] );
-            }
+                {
+                    Platform_Free( pContext->pSocketData[ i ] );
+                }
             #endif
             pContext->pSocketData[ i ] = NULL;
         }
@@ -456,7 +456,7 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
 
         if( ( pContext->bLibShutdown == true ) || ( pContext->bLibClosing == true ) )
         {
-            LogError( ( "Cellular Lib indicated a failure[%"CELLULAR_LOG_FMT_INT"][%"CELLULAR_LOG_FMT_INT"]", pContext->bLibShutdown, pContext->bLibClosing ) );
+            LogError( ( "Cellular Lib indicated a failure[%"CELLULAR_LOG_FMT_INT "][%"CELLULAR_LOG_FMT_INT "]", pContext->bLibShutdown, pContext->bLibClosing ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
 
@@ -487,7 +487,7 @@ CellularError_t _Cellular_TranslatePktStatus( CellularPktStatus_t status )
         case CELLULAR_PKT_STATUS_BAD_RESPONSE:
         case CELLULAR_PKT_STATUS_SIZE_MISMATCH:
         default:
-            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT"", status ) );
+            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT "", status ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
             break;
     }
@@ -517,7 +517,7 @@ CellularPktStatus_t _Cellular_TranslateAtCoreStatus( CellularATError_t status )
         case CELLULAR_AT_ERROR:
         case CELLULAR_AT_UNKNOWN:
         default:
-            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT"", status ) );
+            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT "", status ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
             break;
     }
@@ -545,13 +545,13 @@ CellularError_t _Cellular_CreateSocketData( CellularContext_t * pContext,
         if( pContext->pSocketData[ socketId ] == NULL )
         {
             #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 1 )
-            {
-                pSocketData = &cellularStaticSocketDataTable[ socketId ];
-            }
+                {
+                    pSocketData = &cellularStaticSocketDataTable[ socketId ];
+                }
             #else
-            {
-                pSocketData = ( CellularSocketContext_t * ) Platform_Malloc( sizeof( CellularSocketContext_t ) );
-            }
+                {
+                    pSocketData = ( CellularSocketContext_t * ) Platform_Malloc( sizeof( CellularSocketContext_t ) );
+                }
             #endif
 
             if( pSocketData != NULL )
@@ -599,7 +599,7 @@ CellularError_t _Cellular_RemoveSocketData( CellularContext_t * pContext,
 
     if( socketHandle->socketState == SOCKETSTATE_CONNECTING )
     {
-        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%"CELLULAR_LOG_FMT_UINT32"]", socketHandle->socketId ) );
+        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%"CELLULAR_LOG_FMT_UINT32 "]", socketHandle->socketId ) );
     }
 
     taskENTER_CRITICAL();
@@ -652,7 +652,7 @@ CellularError_t _Cellular_IsValidSocket( const CellularContext_t * pContext,
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %"CELLULAR_LOG_FMT_UINT32"", sockIndex ) );
+            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %"CELLULAR_LOG_FMT_UINT32 "", sockIndex ) );
             cellularStatus = CELLULAR_BAD_PARAMETER;
         }
     }
@@ -668,7 +668,7 @@ CellularError_t _Cellular_IsValidPdn( uint8_t contextId )
 
     if( ( contextId > CELLULAR_PDN_CONTEXT_ID_MAX ) || ( contextId < CELLULAR_PDN_CONTEXT_ID_MIN ) )
     {
-        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT"",
+        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT "",
                     contextId ) );
         cellularStatus = CELLULAR_BAD_PARAMETER;
     }
@@ -701,7 +701,7 @@ CellularError_t _Cellular_ConvertCsqSignalRssi( int16_t csqRssi,
         }
         else
         {
-            rssiValue = ( int16_t )( SIGNAL_QUALITY_CSQ_RSSI_BASE + csqRssi * SIGNAL_QUALITY_CSQ_RSSI_STEP );
+            rssiValue = ( int16_t ) ( SIGNAL_QUALITY_CSQ_RSSI_BASE + csqRssi * SIGNAL_QUALITY_CSQ_RSSI_STEP );
         }
     }
 
@@ -797,12 +797,12 @@ CellularError_t _Cellular_ComputeSignalBars( CellularRat_t rat,
         if( ( rat == CELLULAR_RAT_GSM ) || ( rat == CELLULAR_RAT_EDGE ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rssi, rat );
-            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT" Bars %"CELLULAR_LOG_FMT_INT"", pSignalInfo->rssi, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT " Bars %"CELLULAR_LOG_FMT_INT "", pSignalInfo->rssi, pSignalInfo->bars ) );
         }
         else if( ( rat == CELLULAR_RAT_LTE ) || ( rat == CELLULAR_RAT_CATM1 ) || ( rat == CELLULAR_RAT_NBIOT ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rsrp, rat );
-            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT" Bars %"CELLULAR_LOG_FMT_INT"", pSignalInfo->rsrp, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT " Bars %"CELLULAR_LOG_FMT_INT "", pSignalInfo->rsrp, pSignalInfo->bars ) );
         }
         else
         {
@@ -916,7 +916,7 @@ CellularSocketContext_t * _Cellular_GetSocketData( const CellularContext_t * pCo
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_GetSocketData, invalid socket handle %"CELLULAR_LOG_FMT_UINT32"", sockIndex ) );
+            LogError( ( "_Cellular_GetSocketData, invalid socket handle %"CELLULAR_LOG_FMT_UINT32 "", sockIndex ) );
         }
         else
         {

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -192,7 +192,7 @@ static CellularError_t libOpen( CellularContext_t * pContext )
 
     PlatformMutex_Lock( &pContext->libStatusMutex );
 
-    ( CellularPktStatus_t ) _Cellular_AtParseInit( pContext );
+    ( void ) _Cellular_AtParseInit( pContext );
     _Cellular_LockAtDataMutex( pContext );
     _Cellular_InitAtData( pContext, 0 );
     _Cellular_UnlockAtDataMutex( pContext );

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -487,7 +487,7 @@ CellularError_t _Cellular_TranslatePktStatus( CellularPktStatus_t status )
         case CELLULAR_PKT_STATUS_BAD_RESPONSE:
         case CELLULAR_PKT_STATUS_SIZE_MISMATCH:
         default:
-            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT "", status ) );
+            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT, status ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
             break;
     }
@@ -517,7 +517,7 @@ CellularPktStatus_t _Cellular_TranslateAtCoreStatus( CellularATError_t status )
         case CELLULAR_AT_ERROR:
         case CELLULAR_AT_UNKNOWN:
         default:
-            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT "", status ) );
+            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT, status ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
             break;
     }
@@ -652,7 +652,7 @@ CellularError_t _Cellular_IsValidSocket( const CellularContext_t * pContext,
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %"CELLULAR_LOG_FMT_UINT32 "", sockIndex ) );
+            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %"CELLULAR_LOG_FMT_UINT32, sockIndex ) );
             cellularStatus = CELLULAR_BAD_PARAMETER;
         }
     }
@@ -668,7 +668,7 @@ CellularError_t _Cellular_IsValidPdn( uint8_t contextId )
 
     if( ( contextId > CELLULAR_PDN_CONTEXT_ID_MAX ) || ( contextId < CELLULAR_PDN_CONTEXT_ID_MIN ) )
     {
-        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT "",
+        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT,
                     contextId ) );
         cellularStatus = CELLULAR_BAD_PARAMETER;
     }
@@ -797,12 +797,12 @@ CellularError_t _Cellular_ComputeSignalBars( CellularRat_t rat,
         if( ( rat == CELLULAR_RAT_GSM ) || ( rat == CELLULAR_RAT_EDGE ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rssi, rat );
-            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT " Bars %"CELLULAR_LOG_FMT_INT "", pSignalInfo->rssi, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT " Bars %"CELLULAR_LOG_FMT_INT, pSignalInfo->rssi, pSignalInfo->bars ) );
         }
         else if( ( rat == CELLULAR_RAT_LTE ) || ( rat == CELLULAR_RAT_CATM1 ) || ( rat == CELLULAR_RAT_NBIOT ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rsrp, rat );
-            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT " Bars %"CELLULAR_LOG_FMT_INT "", pSignalInfo->rsrp, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT " Bars %"CELLULAR_LOG_FMT_INT, pSignalInfo->rsrp, pSignalInfo->bars ) );
         }
         else
         {
@@ -916,7 +916,7 @@ CellularSocketContext_t * _Cellular_GetSocketData( const CellularContext_t * pCo
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_GetSocketData, invalid socket handle %"CELLULAR_LOG_FMT_UINT32 "", sockIndex ) );
+            LogError( ( "_Cellular_GetSocketData, invalid socket handle %"CELLULAR_LOG_FMT_UINT32, sockIndex ) );
         }
         else
         {

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -456,7 +456,7 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
 
         if( ( pContext->bLibShutdown == true ) || ( pContext->bLibClosing == true ) )
         {
-            LogError( ( "Cellular Lib indicated a failure[%d][%d]", pContext->bLibShutdown, pContext->bLibClosing ) );
+            LogError( ( "Cellular Lib indicated a failure[%"CELLULAR_LOG_FMT_INT32"][%"CELLULAR_LOG_FMT_INT32"]", pContext->bLibShutdown, pContext->bLibClosing ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
 
@@ -487,7 +487,7 @@ CellularError_t _Cellular_TranslatePktStatus( CellularPktStatus_t status )
         case CELLULAR_PKT_STATUS_BAD_RESPONSE:
         case CELLULAR_PKT_STATUS_SIZE_MISMATCH:
         default:
-            LogError( ( "_Cellular_TranslatePktStatus: Status %d", status ) );
+            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT32"", status ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
             break;
     }
@@ -517,7 +517,7 @@ CellularPktStatus_t _Cellular_TranslateAtCoreStatus( CellularATError_t status )
         case CELLULAR_AT_ERROR:
         case CELLULAR_AT_UNKNOWN:
         default:
-            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %d", status ) );
+            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT32"", status ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
             break;
     }
@@ -599,7 +599,7 @@ CellularError_t _Cellular_RemoveSocketData( CellularContext_t * pContext,
 
     if( socketHandle->socketState == SOCKETSTATE_CONNECTING )
     {
-        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%u]", socketHandle->socketId ) );
+        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%"CELLULAR_LOG_FMT_UINT32"]", socketHandle->socketId ) );
     }
 
     taskENTER_CRITICAL();
@@ -652,7 +652,7 @@ CellularError_t _Cellular_IsValidSocket( const CellularContext_t * pContext,
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %u", sockIndex ) );
+            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %"CELLULAR_LOG_FMT_UINT32"", sockIndex ) );
             cellularStatus = CELLULAR_BAD_PARAMETER;
         }
     }
@@ -668,7 +668,7 @@ CellularError_t _Cellular_IsValidPdn( uint8_t contextId )
 
     if( ( contextId > CELLULAR_PDN_CONTEXT_ID_MAX ) || ( contextId < CELLULAR_PDN_CONTEXT_ID_MIN ) )
     {
-        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %d",
+        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT32"",
                     contextId ) );
         cellularStatus = CELLULAR_BAD_PARAMETER;
     }
@@ -797,12 +797,12 @@ CellularError_t _Cellular_ComputeSignalBars( CellularRat_t rat,
         if( ( rat == CELLULAR_RAT_GSM ) || ( rat == CELLULAR_RAT_EDGE ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rssi, rat );
-            LogDebug( ( "_computeSignalBars: RSSI %d Bars %d", pSignalInfo->rssi, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT32" Bars %"CELLULAR_LOG_FMT_INT32"", pSignalInfo->rssi, pSignalInfo->bars ) );
         }
         else if( ( rat == CELLULAR_RAT_LTE ) || ( rat == CELLULAR_RAT_CATM1 ) || ( rat == CELLULAR_RAT_NBIOT ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rsrp, rat );
-            LogDebug( ( "_computeSignalBars: RSRP %d Bars %d", pSignalInfo->rsrp, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT32" Bars %"CELLULAR_LOG_FMT_INT32"", pSignalInfo->rsrp, pSignalInfo->bars ) );
         }
         else
         {
@@ -916,7 +916,7 @@ CellularSocketContext_t * _Cellular_GetSocketData( const CellularContext_t * pCo
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_GetSocketData, invalid socket handle %u", sockIndex ) );
+            LogError( ( "_Cellular_GetSocketData, invalid socket handle %"CELLULAR_LOG_FMT_UINT32"", sockIndex ) );
         }
         else
         {

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -456,7 +456,7 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
 
         if( ( pContext->bLibShutdown == true ) || ( pContext->bLibClosing == true ) )
         {
-            LogError( ( "Cellular Lib indicated a failure[%"CELLULAR_LOG_FMT_INT32"][%"CELLULAR_LOG_FMT_INT32"]", pContext->bLibShutdown, pContext->bLibClosing ) );
+            LogError( ( "Cellular Lib indicated a failure[%"CELLULAR_LOG_FMT_INT"][%"CELLULAR_LOG_FMT_INT"]", pContext->bLibShutdown, pContext->bLibClosing ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
 
@@ -487,7 +487,7 @@ CellularError_t _Cellular_TranslatePktStatus( CellularPktStatus_t status )
         case CELLULAR_PKT_STATUS_BAD_RESPONSE:
         case CELLULAR_PKT_STATUS_SIZE_MISMATCH:
         default:
-            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT32"", status ) );
+            LogError( ( "_Cellular_TranslatePktStatus: Status %"CELLULAR_LOG_FMT_INT"", status ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
             break;
     }
@@ -517,7 +517,7 @@ CellularPktStatus_t _Cellular_TranslateAtCoreStatus( CellularATError_t status )
         case CELLULAR_AT_ERROR:
         case CELLULAR_AT_UNKNOWN:
         default:
-            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT32"", status ) );
+            LogError( ( "_Cellular_TranslateAtCoreStatus: Status %"CELLULAR_LOG_FMT_INT"", status ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
             break;
     }
@@ -668,7 +668,7 @@ CellularError_t _Cellular_IsValidPdn( uint8_t contextId )
 
     if( ( contextId > CELLULAR_PDN_CONTEXT_ID_MAX ) || ( contextId < CELLULAR_PDN_CONTEXT_ID_MIN ) )
     {
-        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT32"",
+        LogError( ( "_Cellular_IsValidPdn: ContextId out of range %"CELLULAR_LOG_FMT_INT"",
                     contextId ) );
         cellularStatus = CELLULAR_BAD_PARAMETER;
     }
@@ -701,7 +701,7 @@ CellularError_t _Cellular_ConvertCsqSignalRssi( int16_t csqRssi,
         }
         else
         {
-            rssiValue = SIGNAL_QUALITY_CSQ_RSSI_BASE + ( csqRssi * SIGNAL_QUALITY_CSQ_RSSI_STEP );
+            rssiValue = ( int16_t )( SIGNAL_QUALITY_CSQ_RSSI_BASE + csqRssi * SIGNAL_QUALITY_CSQ_RSSI_STEP );
         }
     }
 
@@ -797,12 +797,12 @@ CellularError_t _Cellular_ComputeSignalBars( CellularRat_t rat,
         if( ( rat == CELLULAR_RAT_GSM ) || ( rat == CELLULAR_RAT_EDGE ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rssi, rat );
-            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT32" Bars %"CELLULAR_LOG_FMT_INT32"", pSignalInfo->rssi, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSSI %"CELLULAR_LOG_FMT_INT" Bars %"CELLULAR_LOG_FMT_INT"", pSignalInfo->rssi, pSignalInfo->bars ) );
         }
         else if( ( rat == CELLULAR_RAT_LTE ) || ( rat == CELLULAR_RAT_CATM1 ) || ( rat == CELLULAR_RAT_NBIOT ) )
         {
             pSignalInfo->bars = _getSignalBars( pSignalInfo->rsrp, rat );
-            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT32" Bars %"CELLULAR_LOG_FMT_INT32"", pSignalInfo->rsrp, pSignalInfo->bars ) );
+            LogDebug( ( "_computeSignalBars: RSRP %"CELLULAR_LOG_FMT_INT" Bars %"CELLULAR_LOG_FMT_INT"", pSignalInfo->rsrp, pSignalInfo->bars ) );
         }
         else
         {

--- a/source/cellular_common_api.c
+++ b/source/cellular_common_api.c
@@ -107,7 +107,7 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %"CELLULAR_LOG_FMT_INT" or length %"CELLULAR_LOG_FMT_UINT32" is invalid.",
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %"CELLULAR_LOG_FMT_INT " or length %"CELLULAR_LOG_FMT_UINT32 " is invalid.",
                         socketHandle->socketState, optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
@@ -123,7 +123,7 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %"CELLULAR_LOG_FMT_INT" or length %"CELLULAR_LOG_FMT_UINT32" is invalid.",
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %"CELLULAR_LOG_FMT_INT " or length %"CELLULAR_LOG_FMT_UINT32 " is invalid.",
                         socketHandle->socketState, optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }

--- a/source/cellular_common_api.c
+++ b/source/cellular_common_api.c
@@ -107,7 +107,7 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %d or length %d is invalid.",
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %"CELLULAR_LOG_FMT_INT32" or length %"CELLULAR_LOG_FMT_INT32" is invalid.",
                         socketHandle->socketState, optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
@@ -123,7 +123,7 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %d or length %d is invalid.",
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %"CELLULAR_LOG_FMT_INT32" or length %"CELLULAR_LOG_FMT_INT32" is invalid.",
                         socketHandle->socketState, optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }

--- a/source/cellular_common_api.c
+++ b/source/cellular_common_api.c
@@ -107,7 +107,7 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %"CELLULAR_LOG_FMT_INT32" or length %"CELLULAR_LOG_FMT_INT32" is invalid.",
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %"CELLULAR_LOG_FMT_INT" or length %"CELLULAR_LOG_FMT_UINT32" is invalid.",
                         socketHandle->socketState, optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
@@ -123,7 +123,7 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %"CELLULAR_LOG_FMT_INT32" or length %"CELLULAR_LOG_FMT_INT32" is invalid.",
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %"CELLULAR_LOG_FMT_INT" or length %"CELLULAR_LOG_FMT_UINT32" is invalid.",
                         socketHandle->socketState, optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -137,12 +137,12 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
     if( atStatus != CELLULAR_AT_SUCCESS )
     {
         /* Fail to allocate memory. */
-        LogError( ( "Failed to allocate memory for URC [%s]", pBuf ) );
+        LogError( ( "Failed to allocate memory for URC [%"CELLULAR_LOG_FMT_STR"]", pBuf ) );
         pktStatus = CELLULAR_PKT_STATUS_FAILURE;
     }
     else
     {
-        LogDebug( ( "Next URC token to parse [%s]", pInputLine ) );
+        LogDebug( ( "Next URC token to parse [%"CELLULAR_LOG_FMT_STR"]", pInputLine ) );
 
         /* Check if prefix exist in the input string. The pInputLine is checked in Cellular_ATStrDup. */
         ( void ) Cellular_ATIsPrefixPresent( pInputLine, &inputWithPrefix );
@@ -158,7 +158,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
 
             if( pTokenPtr == NULL )
             {
-                LogError( ( "_Cellular_AtParse : input string error, start with \"+\" but no token %s", pInputLine ) );
+                LogError( ( "_Cellular_AtParse : input string error, start with \"+\" but no token %"CELLULAR_LOG_FMT_STR"", pInputLine ) );
                 pktStatus = CELLULAR_PKT_STATUS_BAD_REQUEST;
             }
             else
@@ -177,7 +177,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
         if( pktStatus == CELLULAR_PKT_STATUS_PREFIX_MISMATCH )
         {
             /* No URC callback function available, check for generic callback. */
-            LogDebug( ( "No URC Callback func avail %s, now trying generic URC Callback", pTokenPtr ) );
+            LogDebug( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR", now trying generic URC Callback", pTokenPtr ) );
 
             if( inputWithPrefix == true )
             {
@@ -213,7 +213,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
     }
     else
     {
-        LogDebug( ( ">>>>>Start sending [%s]<<<<<", atReq.pAtCmd ) );
+        LogDebug( ( ">>>>>Start sending [%"CELLULAR_LOG_FMT_STR"]<<<<<", atReq.pAtCmd ) );
 
         /* Fill in request info structure. */
         PlatformMutex_Lock( &pContext->PktRespMutex );
@@ -240,14 +240,14 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
 
                 if( pktStatus != CELLULAR_PKT_STATUS_OK )
                 {
-                    LogWarn( ( "Modem returns error in sending AT command %s, pktStatus %d.",
+                    LogWarn( ( "Modem returns error in sending AT command %"CELLULAR_LOG_FMT_STR", pktStatus %"CELLULAR_LOG_FMT_INT32".",
                                atReq.pAtCmd, pktStatus ) );
                 } /* Ignore errors from callbacks as they will be handled elsewhere. */
             }
             else
             {
                 pktStatus = CELLULAR_PKT_STATUS_TIMED_OUT;
-                LogError( ( "pkt_recv status=%d, AT cmd %s timed out", pktStatus, atReq.pAtCmd ) );
+                LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT32", AT cmd %"CELLULAR_LOG_FMT_STR" timed out", pktStatus, atReq.pAtCmd ) );
             }
         }
 
@@ -257,7 +257,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         pContext->pktRespCB = NULL;
         pContext->pCurrentCmd = NULL;
         PlatformMutex_Unlock( &pContext->PktRespMutex );
-        LogDebug( ( "<<<<<Exit sending [%s] status[%d]<<<<<", atReq.pAtCmd, pktStatus ) );
+        LogDebug( ( "<<<<<Exit sending [%"CELLULAR_LOG_FMT_STR"] status[%"CELLULAR_LOG_FMT_INT32"]<<<<<", atReq.pAtCmd, pktStatus ) );
     }
 
     return pktStatus;
@@ -329,13 +329,13 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
             }
             else
             {
-                LogWarn( ( "Modem returns error in sending data, pktStatus %d.", pktStatus ) );
+                LogWarn( ( "Modem returns error in sending data, pktStatus %"CELLULAR_LOG_FMT_INT32".", pktStatus ) );
             }
         }
         else
         {
             pktStatus = CELLULAR_PKT_STATUS_TIMED_OUT;
-            LogError( ( "pkt_recv status=%d, data sending timed out", pktStatus ) );
+            LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT32", data sending timed out", pktStatus ) );
         }
 
         /* Set AT command type to CELLULAR_AT_NO_COMMAND for timeout case here. */
@@ -343,7 +343,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
         PlatformMutex_Unlock( &pContext->PktRespMutex );
 
-        LogDebug( ( "<<<<<Exit sending data ret[%d]>>>>>", pktStatus ) );
+        LogDebug( ( "<<<<<Exit sending data ret[%"CELLULAR_LOG_FMT_INT32"]>>>>>", pktStatus ) );
     }
 
     return pktStatus;
@@ -456,7 +456,7 @@ static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
         }
         else
         {
-            LogWarn( ( "No URC Callback func avail %s", pTokenPtr ) );
+            LogWarn( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR"", pTokenPtr ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
         }
     }
@@ -479,13 +479,13 @@ static CellularPktStatus_t _handleUndefinedMessage( CellularContext_t * pContext
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
 
-    LogInfo( ( "AT_UNDEFINED message received %s\r\n", pLine ) );
+    LogInfo( ( "AT_UNDEFINED message received %"CELLULAR_LOG_FMT_STR"\r\n", pLine ) );
 
     /* undefined message received. Try to handle it with cellular module
      * specific handler. */
     if( pContext->undefinedRespCallback == NULL )
     {
-        LogError( ( "No undefined callback for AT_UNDEFINED type message %s received.",
+        LogError( ( "No undefined callback for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR" received.",
                     pLine ) );
         pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
     }
@@ -495,7 +495,7 @@ static CellularPktStatus_t _handleUndefinedMessage( CellularContext_t * pContext
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "undefinedRespCallback returns error %d for AT_UNDEFINED type message %s received.",
+            LogError( ( "undefinedRespCallback returns error %"CELLULAR_LOG_FMT_INT32" for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR" received.",
                         pktStatus, pLine ) );
             pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
         }
@@ -554,7 +554,7 @@ CellularPktStatus_t _Cellular_HandlePacket( CellularContext_t * pContext,
 
             default:
                 pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
-                LogError( ( "_Cellular_HandlePacket Callback type (%d) error", atRespType ) );
+                LogError( ( "_Cellular_HandlePacket Callback type (%"CELLULAR_LOG_FMT_INT32") error", atRespType ) );
                 break;
         }
     }
@@ -820,7 +820,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %u: %d %s %s", i, result,
+                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32": %"CELLULAR_LOG_FMT_INT32" %"CELLULAR_LOG_FMT_STR" %"CELLULAR_LOG_FMT_STR"", i, result,
                             pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }
@@ -836,7 +836,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
         for( i = 0; i < tokenMapSize; i++ )
         {
-            LogDebug( ( "Callbacks setup for %u : %s", i, pTokenMap[ i ].pStrValue ) );
+            LogDebug( ( "Callbacks setup for %"CELLULAR_LOG_FMT_UINT32" : %"CELLULAR_LOG_FMT_STR"", i, pTokenMap[ i ].pStrValue ) );
         }
     }
     else

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -137,12 +137,12 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
     if( atStatus != CELLULAR_AT_SUCCESS )
     {
         /* Fail to allocate memory. */
-        LogError( ( "Failed to allocate memory for URC [%"CELLULAR_LOG_FMT_STR"]", pBuf ) );
+        LogError( ( "Failed to allocate memory for URC [%"CELLULAR_LOG_FMT_STR "]", pBuf ) );
         pktStatus = CELLULAR_PKT_STATUS_FAILURE;
     }
     else
     {
-        LogDebug( ( "Next URC token to parse [%"CELLULAR_LOG_FMT_STR"]", pInputLine ) );
+        LogDebug( ( "Next URC token to parse [%"CELLULAR_LOG_FMT_STR "]", pInputLine ) );
 
         /* Check if prefix exist in the input string. The pInputLine is checked in Cellular_ATStrDup. */
         ( void ) Cellular_ATIsPrefixPresent( pInputLine, &inputWithPrefix );
@@ -158,7 +158,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
 
             if( pTokenPtr == NULL )
             {
-                LogError( ( "_Cellular_AtParse : input string error, start with \"+\" but no token %"CELLULAR_LOG_FMT_STR"", pInputLine ) );
+                LogError( ( "_Cellular_AtParse : input string error, start with \"+\" but no token %"CELLULAR_LOG_FMT_STR "", pInputLine ) );
                 pktStatus = CELLULAR_PKT_STATUS_BAD_REQUEST;
             }
             else
@@ -177,7 +177,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
         if( pktStatus == CELLULAR_PKT_STATUS_PREFIX_MISMATCH )
         {
             /* No URC callback function available, check for generic callback. */
-            LogDebug( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR", now trying generic URC Callback", pTokenPtr ) );
+            LogDebug( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR ", now trying generic URC Callback", pTokenPtr ) );
 
             if( inputWithPrefix == true )
             {
@@ -213,7 +213,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
     }
     else
     {
-        LogDebug( ( ">>>>>Start sending [%"CELLULAR_LOG_FMT_STR"]<<<<<", atReq.pAtCmd ) );
+        LogDebug( ( ">>>>>Start sending [%"CELLULAR_LOG_FMT_STR "]<<<<<", atReq.pAtCmd ) );
 
         /* Fill in request info structure. */
         PlatformMutex_Lock( &pContext->PktRespMutex );
@@ -240,14 +240,14 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
 
                 if( pktStatus != CELLULAR_PKT_STATUS_OK )
                 {
-                    LogWarn( ( "Modem returns error in sending AT command %"CELLULAR_LOG_FMT_STR", pktStatus %"CELLULAR_LOG_FMT_INT".",
+                    LogWarn( ( "Modem returns error in sending AT command %"CELLULAR_LOG_FMT_STR ", pktStatus %"CELLULAR_LOG_FMT_INT ".",
                                atReq.pAtCmd, pktStatus ) );
                 } /* Ignore errors from callbacks as they will be handled elsewhere. */
             }
             else
             {
                 pktStatus = CELLULAR_PKT_STATUS_TIMED_OUT;
-                LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT", AT cmd %"CELLULAR_LOG_FMT_STR" timed out", pktStatus, atReq.pAtCmd ) );
+                LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT ", AT cmd %"CELLULAR_LOG_FMT_STR " timed out", pktStatus, atReq.pAtCmd ) );
             }
         }
 
@@ -257,7 +257,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         pContext->pktRespCB = NULL;
         pContext->pCurrentCmd = NULL;
         PlatformMutex_Unlock( &pContext->PktRespMutex );
-        LogDebug( ( "<<<<<Exit sending [%"CELLULAR_LOG_FMT_STR"] status[%"CELLULAR_LOG_FMT_INT"]<<<<<", atReq.pAtCmd, pktStatus ) );
+        LogDebug( ( "<<<<<Exit sending [%"CELLULAR_LOG_FMT_STR "] status[%"CELLULAR_LOG_FMT_INT "]<<<<<", atReq.pAtCmd, pktStatus ) );
     }
 
     return pktStatus;
@@ -329,13 +329,13 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
             }
             else
             {
-                LogWarn( ( "Modem returns error in sending data, pktStatus %"CELLULAR_LOG_FMT_INT".", pktStatus ) );
+                LogWarn( ( "Modem returns error in sending data, pktStatus %"CELLULAR_LOG_FMT_INT ".", pktStatus ) );
             }
         }
         else
         {
             pktStatus = CELLULAR_PKT_STATUS_TIMED_OUT;
-            LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT", data sending timed out", pktStatus ) );
+            LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT ", data sending timed out", pktStatus ) );
         }
 
         /* Set AT command type to CELLULAR_AT_NO_COMMAND for timeout case here. */
@@ -343,7 +343,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
         PlatformMutex_Unlock( &pContext->PktRespMutex );
 
-        LogDebug( ( "<<<<<Exit sending data ret[%"CELLULAR_LOG_FMT_INT"]>>>>>", pktStatus ) );
+        LogDebug( ( "<<<<<Exit sending data ret[%"CELLULAR_LOG_FMT_INT "]>>>>>", pktStatus ) );
     }
 
     return pktStatus;
@@ -456,7 +456,7 @@ static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
         }
         else
         {
-            LogWarn( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR"", pTokenPtr ) );
+            LogWarn( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR "", pTokenPtr ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
         }
     }
@@ -479,13 +479,13 @@ static CellularPktStatus_t _handleUndefinedMessage( CellularContext_t * pContext
 {
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
 
-    LogInfo( ( "AT_UNDEFINED message received %"CELLULAR_LOG_FMT_STR"\r\n", pLine ) );
+    LogInfo( ( "AT_UNDEFINED message received %"CELLULAR_LOG_FMT_STR "\r\n", pLine ) );
 
     /* undefined message received. Try to handle it with cellular module
      * specific handler. */
     if( pContext->undefinedRespCallback == NULL )
     {
-        LogError( ( "No undefined callback for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR" received.",
+        LogError( ( "No undefined callback for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR " received.",
                     pLine ) );
         pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
     }
@@ -495,7 +495,7 @@ static CellularPktStatus_t _handleUndefinedMessage( CellularContext_t * pContext
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "undefinedRespCallback returns error %"CELLULAR_LOG_FMT_INT" for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR" received.",
+            LogError( ( "undefinedRespCallback returns error %"CELLULAR_LOG_FMT_INT " for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR " received.",
                         pktStatus, pLine ) );
             pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
         }
@@ -554,7 +554,7 @@ CellularPktStatus_t _Cellular_HandlePacket( CellularContext_t * pContext,
 
             default:
                 pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
-                LogError( ( "_Cellular_HandlePacket Callback type (%"CELLULAR_LOG_FMT_INT") error", atRespType ) );
+                LogError( ( "_Cellular_HandlePacket Callback type (%"CELLULAR_LOG_FMT_INT ") error", atRespType ) );
                 break;
         }
     }
@@ -820,7 +820,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32": %"CELLULAR_LOG_FMT_INT32" %"CELLULAR_LOG_FMT_STR" %"CELLULAR_LOG_FMT_STR"",
+                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32 ": %"CELLULAR_LOG_FMT_INT32 " %"CELLULAR_LOG_FMT_STR " %"CELLULAR_LOG_FMT_STR "",
                             i, result, pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }
@@ -836,7 +836,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
         for( i = 0; i < tokenMapSize; i++ )
         {
-            LogDebug( ( "Callbacks setup for %"CELLULAR_LOG_FMT_UINT32" : %"CELLULAR_LOG_FMT_STR"", i, pTokenMap[ i ].pStrValue ) );
+            LogDebug( ( "Callbacks setup for %"CELLULAR_LOG_FMT_UINT32 " : %"CELLULAR_LOG_FMT_STR "", i, pTokenMap[ i ].pStrValue ) );
         }
     }
     else

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -158,7 +158,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
 
             if( pTokenPtr == NULL )
             {
-                LogError( ( "_Cellular_AtParse : input string error, start with \"+\" but no token %"CELLULAR_LOG_FMT_STR "", pInputLine ) );
+                LogError( ( "_Cellular_AtParse : input string error, start with \"+\" but no token %"CELLULAR_LOG_FMT_STR, pInputLine ) );
                 pktStatus = CELLULAR_PKT_STATUS_BAD_REQUEST;
             }
             else
@@ -456,7 +456,7 @@ static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
         }
         else
         {
-            LogWarn( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR "", pTokenPtr ) );
+            LogWarn( ( "No URC Callback func avail %"CELLULAR_LOG_FMT_STR, pTokenPtr ) );
             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
         }
     }
@@ -820,7 +820,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32 ": %"CELLULAR_LOG_FMT_INT32 " %"CELLULAR_LOG_FMT_STR " %"CELLULAR_LOG_FMT_STR "",
+                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32 ": %"CELLULAR_LOG_FMT_INT32 " %"CELLULAR_LOG_FMT_STR " %"CELLULAR_LOG_FMT_STR,
                             i, result, pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }
@@ -836,7 +836,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
         for( i = 0; i < tokenMapSize; i++ )
         {
-            LogDebug( ( "Callbacks setup for %"CELLULAR_LOG_FMT_UINT32 " : %"CELLULAR_LOG_FMT_STR "", i, pTokenMap[ i ].pStrValue ) );
+            LogDebug( ( "Callbacks setup for %"CELLULAR_LOG_FMT_UINT32 " : %"CELLULAR_LOG_FMT_STR, i, pTokenMap[ i ].pStrValue ) );
         }
     }
     else

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -240,14 +240,14 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
 
                 if( pktStatus != CELLULAR_PKT_STATUS_OK )
                 {
-                    LogWarn( ( "Modem returns error in sending AT command %"CELLULAR_LOG_FMT_STR", pktStatus %"CELLULAR_LOG_FMT_INT32".",
+                    LogWarn( ( "Modem returns error in sending AT command %"CELLULAR_LOG_FMT_STR", pktStatus %"CELLULAR_LOG_FMT_INT".",
                                atReq.pAtCmd, pktStatus ) );
                 } /* Ignore errors from callbacks as they will be handled elsewhere. */
             }
             else
             {
                 pktStatus = CELLULAR_PKT_STATUS_TIMED_OUT;
-                LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT32", AT cmd %"CELLULAR_LOG_FMT_STR" timed out", pktStatus, atReq.pAtCmd ) );
+                LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT", AT cmd %"CELLULAR_LOG_FMT_STR" timed out", pktStatus, atReq.pAtCmd ) );
             }
         }
 
@@ -257,7 +257,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         pContext->pktRespCB = NULL;
         pContext->pCurrentCmd = NULL;
         PlatformMutex_Unlock( &pContext->PktRespMutex );
-        LogDebug( ( "<<<<<Exit sending [%"CELLULAR_LOG_FMT_STR"] status[%"CELLULAR_LOG_FMT_INT32"]<<<<<", atReq.pAtCmd, pktStatus ) );
+        LogDebug( ( "<<<<<Exit sending [%"CELLULAR_LOG_FMT_STR"] status[%"CELLULAR_LOG_FMT_INT"]<<<<<", atReq.pAtCmd, pktStatus ) );
     }
 
     return pktStatus;
@@ -329,13 +329,13 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
             }
             else
             {
-                LogWarn( ( "Modem returns error in sending data, pktStatus %"CELLULAR_LOG_FMT_INT32".", pktStatus ) );
+                LogWarn( ( "Modem returns error in sending data, pktStatus %"CELLULAR_LOG_FMT_INT".", pktStatus ) );
             }
         }
         else
         {
             pktStatus = CELLULAR_PKT_STATUS_TIMED_OUT;
-            LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT32", data sending timed out", pktStatus ) );
+            LogError( ( "pkt_recv status=%"CELLULAR_LOG_FMT_INT", data sending timed out", pktStatus ) );
         }
 
         /* Set AT command type to CELLULAR_AT_NO_COMMAND for timeout case here. */
@@ -343,7 +343,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
         PlatformMutex_Unlock( &pContext->PktRespMutex );
 
-        LogDebug( ( "<<<<<Exit sending data ret[%"CELLULAR_LOG_FMT_INT32"]>>>>>", pktStatus ) );
+        LogDebug( ( "<<<<<Exit sending data ret[%"CELLULAR_LOG_FMT_INT"]>>>>>", pktStatus ) );
     }
 
     return pktStatus;
@@ -495,7 +495,7 @@ static CellularPktStatus_t _handleUndefinedMessage( CellularContext_t * pContext
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "undefinedRespCallback returns error %"CELLULAR_LOG_FMT_INT32" for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR" received.",
+            LogError( ( "undefinedRespCallback returns error %"CELLULAR_LOG_FMT_INT" for AT_UNDEFINED type message %"CELLULAR_LOG_FMT_STR" received.",
                         pktStatus, pLine ) );
             pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
         }
@@ -554,7 +554,7 @@ CellularPktStatus_t _Cellular_HandlePacket( CellularContext_t * pContext,
 
             default:
                 pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
-                LogError( ( "_Cellular_HandlePacket Callback type (%"CELLULAR_LOG_FMT_INT32") error", atRespType ) );
+                LogError( ( "_Cellular_HandlePacket Callback type (%"CELLULAR_LOG_FMT_INT") error", atRespType ) );
                 break;
         }
     }
@@ -820,8 +820,8 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32": %"CELLULAR_LOG_FMT_INT32" %"CELLULAR_LOG_FMT_STR" %"CELLULAR_LOG_FMT_STR"", i, result,
-                            pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
+                LogError( ( "AtParseFail for %"CELLULAR_LOG_FMT_UINT32": %"CELLULAR_LOG_FMT_INT32" %"CELLULAR_LOG_FMT_STR" %"CELLULAR_LOG_FMT_STR"",
+                            i, result, pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }
         }

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -142,7 +142,7 @@ static void _saveData( char * pLine,
 
     ( void ) dataLen;
 
-    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR" with length %"CELLULAR_LOG_FMT_UINT32"", pLine, dataLen ) );
+    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR " with length %"CELLULAR_LOG_FMT_UINT32 "", pLine, dataLen ) );
 
     pNew = ( CellularATCommandLine_t * ) Platform_Malloc( sizeof( CellularATCommandLine_t ) );
     configASSERT( ( pNew != NULL ) );
@@ -174,7 +174,7 @@ static void _saveRawData( char * pLine,
                           CellularATCommandResponse_t * pResp,
                           uint32_t dataLen )
 {
-    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_PTR"] %"CELLULAR_LOG_FMT_UINT32" data to pResp", pLine, dataLen ) );
+    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_PTR "] %"CELLULAR_LOG_FMT_UINT32 " data to pResp", pLine, dataLen ) );
     _saveData( pLine, pResp, dataLen );
 }
 
@@ -183,7 +183,7 @@ static void _saveRawData( char * pLine,
 static void _saveATData( char * pLine,
                          CellularATCommandResponse_t * pResp )
 {
-    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_STR"] %"CELLULAR_LOG_FMT_SIZE" AT data to pResp", pLine, strlen( pLine ) ) );
+    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_STR "] %"CELLULAR_LOG_FMT_SIZE " AT data to pResp", pLine, strlen( pLine ) ) );
     _saveData( pLine, pResp, ( uint32_t ) ( strlen( pLine ) + 1U ) );
 }
 
@@ -207,7 +207,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT", previous line %"CELLULAR_LOG_FMT_STR"",
+                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR ", status: %"CELLULAR_LOG_FMT_INT ", previous line %"CELLULAR_LOG_FMT_STR "",
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -226,7 +226,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT", previous line %"CELLULAR_LOG_FMT_STR"",
+                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR ", status: %"CELLULAR_LOG_FMT_INT ", previous line %"CELLULAR_LOG_FMT_STR "",
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -264,7 +264,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
 
         default:
             /* Unexpected message received when sending the AT command. */
-            LogInfo( ( "Undefind message received %"CELLULAR_LOG_FMT_STR" when sending AT command type %"CELLULAR_LOG_FMT_INT".",
+            LogInfo( ( "Undefind message received %"CELLULAR_LOG_FMT_STR " when sending AT command type %"CELLULAR_LOG_FMT_INT ".",
                        pLine, atType ) );
 
             pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
@@ -361,7 +361,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
         {
             pResp->status = true;
             pkStatus = CELLULAR_PKT_STATUS_OK;
-            LogDebug( ( "Final AT response is SUCCESS [%"CELLULAR_LOG_FMT_STR"] in extra table", pLine ) );
+            LogDebug( ( "Final AT response is SUCCESS [%"CELLULAR_LOG_FMT_STR "] in extra table", pLine ) );
         }
         else
         {
@@ -372,7 +372,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
             {
                 pResp->status = true;
                 pkStatus = CELLULAR_PKT_STATUS_OK;
-                LogDebug( ( "Final AT response is SUCCESS [%"CELLULAR_LOG_FMT_STR"]", pLine ) );
+                LogDebug( ( "Final AT response is SUCCESS [%"CELLULAR_LOG_FMT_STR "]", pLine ) );
             }
         }
 
@@ -396,7 +396,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
 
     if( ( result == true ) && ( pResp->status == false ) )
     {
-        LogWarn( ( "Modem return ERROR: line %"CELLULAR_LOG_FMT_STR", cmd : %"CELLULAR_LOG_FMT_STR", respPrefix %"CELLULAR_LOG_FMT_STR"",
+        LogWarn( ( "Modem return ERROR: line %"CELLULAR_LOG_FMT_STR ", cmd : %"CELLULAR_LOG_FMT_STR ", respPrefix %"CELLULAR_LOG_FMT_STR "",
                    pLine,
                    ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ),
                    ( pRespPrefix != NULL ? pRespPrefix : "NULL" ) ) );
@@ -546,7 +546,7 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     /* Move the leftover data or AT command response to the start of buffer.
      * Set the pRead pointer to the empty buffer space. */
 
-    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR" to %"CELLULAR_LOG_FMT_PTR" %"CELLULAR_LOG_FMT_UINT32"",
+    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR " to %"CELLULAR_LOG_FMT_PTR " %"CELLULAR_LOG_FMT_UINT32 "",
                 pContext->pPktioReadPtr, pContext->pktioReadBuf, pContext->partialDataRcvdLen ) );
 
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
@@ -609,7 +609,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
     if( bufferEmptyLength > 0 )
     {
         ( void ) pContext->pCommIntf->recv( pContext->hPktioCommIntf, ( uint8_t * ) pRead,
-                                            ( uint32_t )bufferEmptyLength,
+                                            ( uint32_t ) bufferEmptyLength,
                                             CELLULAR_COMM_IF_RECV_TIMEOUT_MS, &bytesRead );
 
         if( bytesRead > 0U )
@@ -617,7 +617,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
             /* Add a NULL after the bytesRead. This is required for further processing. */
             pRead[ bytesRead ] = '\0';
 
-            LogDebug( ( "AT Read %"CELLULAR_LOG_FMT_UINT32" bytes, data[%"CELLULAR_LOG_FMT_PTR"]", bytesRead, pRead ) );
+            LogDebug( ( "AT Read %"CELLULAR_LOG_FMT_UINT32 " bytes, data[%"CELLULAR_LOG_FMT_PTR "]", bytesRead, pRead ) );
             /* Set the pBytesRead only when actual bytes read from comm interface. */
             *pBytesRead = bytesRead + partialDataRead;
 
@@ -670,7 +670,7 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
 
-        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR" start %"CELLULAR_LOG_FMT_PTR" prefix %"CELLULAR_LOG_FMT_UINT32" left %"CELLULAR_LOG_FMT_UINT32", read total %"CELLULAR_LOG_FMT_UINT32"",
+        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR " start %"CELLULAR_LOG_FMT_PTR " prefix %"CELLULAR_LOG_FMT_UINT32 " left %"CELLULAR_LOG_FMT_UINT32 ", read total %"CELLULAR_LOG_FMT_UINT32 "",
                     pContext->pktioReadBuf,
                     pStartOfData,
                     bytesBeforeData,
@@ -715,10 +715,10 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
         if( *ppAtResp == NULL )
         {
             *ppAtResp = _Cellular_AtResponseNew();
-            LogDebug( ( "Allocate at response %"CELLULAR_LOG_FMT_PTR"", ( void * ) *ppAtResp ) );
+            LogDebug( ( "Allocate at response %"CELLULAR_LOG_FMT_PTR "", ( void * ) *ppAtResp ) );
         }
 
-        LogDebug( ( "AT solicited Resp[%"CELLULAR_LOG_FMT_STR"]", pLine ) );
+        LogDebug( ( "AT solicited Resp[%"CELLULAR_LOG_FMT_STR "]", pLine ) );
 
         /* Process Line will store the Line data in AT response. */
         pkStatus = _Cellular_ProcessLine( pContext, pLine, *ppAtResp, pContext->PktioAtCmdType, pContext->pRespPrefix );
@@ -772,7 +772,7 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
 
         if( pkStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "recvdMsgType is AT_UNDEFINED for Message: %"CELLULAR_LOG_FMT_STR", cmd %"CELLULAR_LOG_FMT_STR"",
+            LogError( ( "recvdMsgType is AT_UNDEFINED for Message: %"CELLULAR_LOG_FMT_STR ", cmd %"CELLULAR_LOG_FMT_STR "",
                         pLine,
                         ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ) ) );
 
@@ -828,7 +828,7 @@ static bool _findLineInStream( CellularContext_t * pContext,
     }
     else
     {
-        LogDebug( ( "%"CELLULAR_LOG_FMT_PTR" is not a complete line", pTempLine ) );
+        LogDebug( ( "%"CELLULAR_LOG_FMT_PTR " is not a complete line", pTempLine ) );
         pContext->pPktioReadPtr = pTempLine;
         pContext->partialDataRcvdLen = bytesRead;
         keepProcess = false;
@@ -874,7 +874,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
         else if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             /* Modem returns unexpected response. */
-            LogError( ( "Input buffer callback returns error %"CELLULAR_LOG_FMT_INT". Clean the read buffer.", pktStatus ) );
+            LogError( ( "Input buffer callback returns error %"CELLULAR_LOG_FMT_INT ". Clean the read buffer.", pktStatus ) );
 
             /* Clean the read buffer and read pointer. */
             ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
@@ -885,7 +885,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
         else if( bufferLength > *pBytesRead )
         {
             /* The input buffer callback returns incorrect buffer length. */
-            LogError( ( "Input buffer callback returns bufferLength %"CELLULAR_LOG_FMT_UINT32". Modem returns length %"CELLULAR_LOG_FMT_UINT32". Clean the read buffer.",
+            LogError( ( "Input buffer callback returns bufferLength %"CELLULAR_LOG_FMT_UINT32 ". Modem returns length %"CELLULAR_LOG_FMT_UINT32 ". Clean the read buffer.",
                         bufferLength, *pBytesRead ) );
 
             /* Clean the read buffer and read pointer. */
@@ -954,7 +954,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT"", pktStatus ) );
+                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT "", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -982,14 +982,14 @@ static bool _preprocessLine( CellularContext_t * pContext,
             else if( pktStatus == CELLULAR_PKT_STATUS_SIZE_MISMATCH )
             {
                 /* The modem driver is waiting for more data to decide. */
-                LogDebug( ( "%"CELLULAR_LOG_FMT_PTR" is not a complete line", pTempLine ) );
+                LogDebug( ( "%"CELLULAR_LOG_FMT_PTR " is not a complete line", pTempLine ) );
                 pContext->pPktioReadPtr = pTempLine;
                 pContext->partialDataRcvdLen = *pBytesRead;
                 keepProcess = false;
             }
             else
             {
-                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT"", pktStatus ) );
+                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT "", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1026,7 +1026,7 @@ static bool _handleDataResult( CellularContext_t * pContext,
     else
     {
         *pBytesRead = bytesLeft;
-        LogDebug( ( "_handleData okay, keep processing %"CELLULAR_LOG_FMT_UINT32" bytes %"CELLULAR_LOG_FMT_PTR"", bytesLeft, *ppLine ) );
+        LogDebug( ( "_handleData okay, keep processing %"CELLULAR_LOG_FMT_UINT32 " bytes %"CELLULAR_LOG_FMT_PTR "", bytesLeft, *ppLine ) );
     }
 
     return keepProcess;
@@ -1131,7 +1131,7 @@ static void _handleAllReceived( CellularContext_t * pContext,
             }
             else
             {
-                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT"", pktStatus ) );
+                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT "", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1427,7 +1427,7 @@ uint32_t _Cellular_PktioSendData( CellularContext_t * pContext,
                                             dataLen, CELLULAR_COMM_IF_SEND_TIMEOUT_MS, &sentLen );
     }
 
-    LogDebug( ( "PktioSendData sent %"CELLULAR_LOG_FMT_UINT32" bytes", sentLen ) );
+    LogDebug( ( "PktioSendData sent %"CELLULAR_LOG_FMT_UINT32 " bytes", sentLen ) );
     return sentLen;
 }
 

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -142,7 +142,7 @@ static void _saveData( char * pLine,
 
     ( void ) dataLen;
 
-    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR " with length %"CELLULAR_LOG_FMT_UINT32 "", pLine, dataLen ) );
+    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR " with length %"CELLULAR_LOG_FMT_UINT32, pLine, dataLen ) );
 
     pNew = ( CellularATCommandLine_t * ) Platform_Malloc( sizeof( CellularATCommandLine_t ) );
     configASSERT( ( pNew != NULL ) );
@@ -207,7 +207,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR ", status: %"CELLULAR_LOG_FMT_INT ", previous line %"CELLULAR_LOG_FMT_STR "",
+                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR ", status: %"CELLULAR_LOG_FMT_INT ", previous line %"CELLULAR_LOG_FMT_STR,
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -226,7 +226,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR ", status: %"CELLULAR_LOG_FMT_INT ", previous line %"CELLULAR_LOG_FMT_STR "",
+                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR ", status: %"CELLULAR_LOG_FMT_INT ", previous line %"CELLULAR_LOG_FMT_STR,
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -396,7 +396,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
 
     if( ( result == true ) && ( pResp->status == false ) )
     {
-        LogWarn( ( "Modem return ERROR: line %"CELLULAR_LOG_FMT_STR ", cmd : %"CELLULAR_LOG_FMT_STR ", respPrefix %"CELLULAR_LOG_FMT_STR "",
+        LogWarn( ( "Modem return ERROR: line %"CELLULAR_LOG_FMT_STR ", cmd : %"CELLULAR_LOG_FMT_STR ", respPrefix %"CELLULAR_LOG_FMT_STR,
                    pLine,
                    ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ),
                    ( pRespPrefix != NULL ? pRespPrefix : "NULL" ) ) );
@@ -546,7 +546,7 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     /* Move the leftover data or AT command response to the start of buffer.
      * Set the pRead pointer to the empty buffer space. */
 
-    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR " to %"CELLULAR_LOG_FMT_PTR " %"CELLULAR_LOG_FMT_UINT32 "",
+    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR " to %"CELLULAR_LOG_FMT_PTR " %"CELLULAR_LOG_FMT_UINT32,
                 pContext->pPktioReadPtr, pContext->pktioReadBuf, pContext->partialDataRcvdLen ) );
 
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
@@ -670,7 +670,7 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
 
-        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR " start %"CELLULAR_LOG_FMT_PTR " prefix %"CELLULAR_LOG_FMT_UINT32 " left %"CELLULAR_LOG_FMT_UINT32 ", read total %"CELLULAR_LOG_FMT_UINT32 "",
+        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR " start %"CELLULAR_LOG_FMT_PTR " prefix %"CELLULAR_LOG_FMT_UINT32 " left %"CELLULAR_LOG_FMT_UINT32 ", read total %"CELLULAR_LOG_FMT_UINT32,
                     pContext->pktioReadBuf,
                     pStartOfData,
                     bytesBeforeData,
@@ -715,7 +715,7 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
         if( *ppAtResp == NULL )
         {
             *ppAtResp = _Cellular_AtResponseNew();
-            LogDebug( ( "Allocate at response %"CELLULAR_LOG_FMT_PTR "", ( void * ) *ppAtResp ) );
+            LogDebug( ( "Allocate at response %"CELLULAR_LOG_FMT_PTR, ( void * ) *ppAtResp ) );
         }
 
         LogDebug( ( "AT solicited Resp[%"CELLULAR_LOG_FMT_STR "]", pLine ) );
@@ -772,7 +772,7 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
 
         if( pkStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "recvdMsgType is AT_UNDEFINED for Message: %"CELLULAR_LOG_FMT_STR ", cmd %"CELLULAR_LOG_FMT_STR "",
+            LogError( ( "recvdMsgType is AT_UNDEFINED for Message: %"CELLULAR_LOG_FMT_STR ", cmd %"CELLULAR_LOG_FMT_STR,
                         pLine,
                         ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ) ) );
 
@@ -954,7 +954,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT "", pktStatus ) );
+                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT, pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -989,7 +989,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
             }
             else
             {
-                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT "", pktStatus ) );
+                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT, pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1026,7 +1026,7 @@ static bool _handleDataResult( CellularContext_t * pContext,
     else
     {
         *pBytesRead = bytesLeft;
-        LogDebug( ( "_handleData okay, keep processing %"CELLULAR_LOG_FMT_UINT32 " bytes %"CELLULAR_LOG_FMT_PTR "", bytesLeft, *ppLine ) );
+        LogDebug( ( "_handleData okay, keep processing %"CELLULAR_LOG_FMT_UINT32 " bytes %"CELLULAR_LOG_FMT_PTR, bytesLeft, *ppLine ) );
     }
 
     return keepProcess;
@@ -1131,7 +1131,7 @@ static void _handleAllReceived( CellularContext_t * pContext,
             }
             else
             {
-                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT "", pktStatus ) );
+                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT, pktStatus ) );
                 keepProcess = false;
             }
         }

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -142,7 +142,7 @@ static void _saveData( char * pLine,
 
     ( void ) dataLen;
 
-    LogDebug( ( "_saveData : Save data %p with length %d", pLine, dataLen ) );
+    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR" with length %"CELLULAR_LOG_FMT_INT32"", pLine, dataLen ) );
 
     pNew = ( CellularATCommandLine_t * ) Platform_Malloc( sizeof( CellularATCommandLine_t ) );
     configASSERT( ( pNew != NULL ) );
@@ -174,7 +174,7 @@ static void _saveRawData( char * pLine,
                           CellularATCommandResponse_t * pResp,
                           uint32_t dataLen )
 {
-    LogDebug( ( "Save [%p] %d data to pResp", pLine, dataLen ) );
+    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_PTR"] %"CELLULAR_LOG_FMT_INT32" data to pResp", pLine, dataLen ) );
     _saveData( pLine, pResp, dataLen );
 }
 
@@ -183,7 +183,7 @@ static void _saveRawData( char * pLine,
 static void _saveATData( char * pLine,
                          CellularATCommandResponse_t * pResp )
 {
-    LogDebug( ( "Save [%s] %lu AT data to pResp", pLine, strlen( pLine ) ) );
+    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_STR"] %"CELLULAR_LOG_FMT_UINT32" AT data to pResp", pLine, strlen( pLine ) ) );
     _saveData( pLine, pResp, ( uint32_t ) ( strlen( pLine ) + 1U ) );
 }
 
@@ -207,7 +207,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %s, status: %d, previous line %s",
+                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT32", previous line %"CELLULAR_LOG_FMT_STR"",
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -226,7 +226,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %s, status: %d, previous line %s",
+                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT32", previous line %"CELLULAR_LOG_FMT_STR"",
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -264,7 +264,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
 
         default:
             /* Unexpected message received when sending the AT command. */
-            LogInfo( ( "Undefind message received %s when sending AT command type %d.",
+            LogInfo( ( "Undefind message received %"CELLULAR_LOG_FMT_STR" when sending AT command type %"CELLULAR_LOG_FMT_INT32".",
                        pLine, atType ) );
 
             pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
@@ -361,7 +361,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
         {
             pResp->status = true;
             pkStatus = CELLULAR_PKT_STATUS_OK;
-            LogDebug( ( "Final AT response is SUCCESS [%s] in extra table", pLine ) );
+            LogDebug( ( "Final AT response is SUCCESS [%"CELLULAR_LOG_FMT_STR"] in extra table", pLine ) );
         }
         else
         {
@@ -372,7 +372,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
             {
                 pResp->status = true;
                 pkStatus = CELLULAR_PKT_STATUS_OK;
-                LogDebug( ( "Final AT response is SUCCESS [%s]", pLine ) );
+                LogDebug( ( "Final AT response is SUCCESS [%"CELLULAR_LOG_FMT_STR"]", pLine ) );
             }
         }
 
@@ -396,7 +396,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
 
     if( ( result == true ) && ( pResp->status == false ) )
     {
-        LogWarn( ( "Modem return ERROR: line %s, cmd : %s, respPrefix %s",
+        LogWarn( ( "Modem return ERROR: line %"CELLULAR_LOG_FMT_STR", cmd : %"CELLULAR_LOG_FMT_STR", respPrefix %"CELLULAR_LOG_FMT_STR"",
                    pLine,
                    ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ),
                    ( pRespPrefix != NULL ? pRespPrefix : "NULL" ) ) );
@@ -546,7 +546,7 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     /* Move the leftover data or AT command response to the start of buffer.
      * Set the pRead pointer to the empty buffer space. */
 
-    LogDebug( ( "moved the partial line/data from %p to %p %d",
+    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR" to %"CELLULAR_LOG_FMT_PTR" %"CELLULAR_LOG_FMT_INT32"",
                 pContext->pPktioReadPtr, pContext->pktioReadBuf, pContext->partialDataRcvdLen ) );
 
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
@@ -617,7 +617,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
             /* Add a NULL after the bytesRead. This is required for further processing. */
             pRead[ bytesRead ] = '\0';
 
-            LogDebug( ( "AT Read %d bytes, data[%p]", bytesRead, pRead ) );
+            LogDebug( ( "AT Read %"CELLULAR_LOG_FMT_INT32" bytes, data[%"CELLULAR_LOG_FMT_PTR"]", bytesRead, pRead ) );
             /* Set the pBytesRead only when actual bytes read from comm interface. */
             *pBytesRead = bytesRead + partialDataRead;
 
@@ -670,7 +670,7 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
 
-        LogDebug( ( "_handleData : read buffer buffer %p start %p prefix %d left %d, read total %d",
+        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR" start %"CELLULAR_LOG_FMT_PTR" prefix %"CELLULAR_LOG_FMT_INT32" left %"CELLULAR_LOG_FMT_INT32", read total %"CELLULAR_LOG_FMT_INT32"",
                     pContext->pktioReadBuf,
                     pStartOfData,
                     bytesBeforeData,
@@ -715,10 +715,10 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
         if( *ppAtResp == NULL )
         {
             *ppAtResp = _Cellular_AtResponseNew();
-            LogDebug( ( "Allocate at response %p", ( void * ) *ppAtResp ) );
+            LogDebug( ( "Allocate at response %"CELLULAR_LOG_FMT_PTR"", ( void * ) *ppAtResp ) );
         }
 
-        LogDebug( ( "AT solicited Resp[%s]", pLine ) );
+        LogDebug( ( "AT solicited Resp[%"CELLULAR_LOG_FMT_STR"]", pLine ) );
 
         /* Process Line will store the Line data in AT response. */
         pkStatus = _Cellular_ProcessLine( pContext, pLine, *ppAtResp, pContext->PktioAtCmdType, pContext->pRespPrefix );
@@ -772,7 +772,7 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
 
         if( pkStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "recvdMsgType is AT_UNDEFINED for Message: %s, cmd %s",
+            LogError( ( "recvdMsgType is AT_UNDEFINED for Message: %"CELLULAR_LOG_FMT_STR", cmd %"CELLULAR_LOG_FMT_STR"",
                         pLine,
                         ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ) ) );
 
@@ -828,7 +828,7 @@ static bool _findLineInStream( CellularContext_t * pContext,
     }
     else
     {
-        LogDebug( ( "%p is not a complete line", pTempLine ) );
+        LogDebug( ( "%"CELLULAR_LOG_FMT_PTR" is not a complete line", pTempLine ) );
         pContext->pPktioReadPtr = pTempLine;
         pContext->partialDataRcvdLen = bytesRead;
         keepProcess = false;
@@ -874,7 +874,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
         else if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             /* Modem returns unexpected response. */
-            LogError( ( "Input buffer callback returns error %d. Clean the read buffer.", pktStatus ) );
+            LogError( ( "Input buffer callback returns error %"CELLULAR_LOG_FMT_INT32". Clean the read buffer.", pktStatus ) );
 
             /* Clean the read buffer and read pointer. */
             ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
@@ -885,7 +885,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
         else if( bufferLength > *pBytesRead )
         {
             /* The input buffer callback returns incorrect buffer length. */
-            LogError( ( "Input buffer callback returns bufferLength %u. Modem returns length %u. Clean the read buffer.",
+            LogError( ( "Input buffer callback returns bufferLength %"CELLULAR_LOG_FMT_UINT32". Modem returns length %"CELLULAR_LOG_FMT_UINT32". Clean the read buffer.",
                         bufferLength, *pBytesRead ) );
 
             /* Clean the read buffer and read pointer. */
@@ -954,7 +954,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "pktDataSendPrefixCB returns error %d", pktStatus ) );
+                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -982,14 +982,14 @@ static bool _preprocessLine( CellularContext_t * pContext,
             else if( pktStatus == CELLULAR_PKT_STATUS_SIZE_MISMATCH )
             {
                 /* The modem driver is waiting for more data to decide. */
-                LogDebug( ( "%p is not a complete line", pTempLine ) );
+                LogDebug( ( "%"CELLULAR_LOG_FMT_PTR" is not a complete line", pTempLine ) );
                 pContext->pPktioReadPtr = pTempLine;
                 pContext->partialDataRcvdLen = *pBytesRead;
                 keepProcess = false;
             }
             else
             {
-                LogError( ( "pktDataPrefixCB returns error %d", pktStatus ) );
+                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1026,7 +1026,7 @@ static bool _handleDataResult( CellularContext_t * pContext,
     else
     {
         *pBytesRead = bytesLeft;
-        LogDebug( ( "_handleData okay, keep processing %u bytes %p", bytesLeft, *ppLine ) );
+        LogDebug( ( "_handleData okay, keep processing %"CELLULAR_LOG_FMT_UINT32" bytes %"CELLULAR_LOG_FMT_PTR"", bytesLeft, *ppLine ) );
     }
 
     return keepProcess;
@@ -1131,7 +1131,7 @@ static void _handleAllReceived( CellularContext_t * pContext,
             }
             else
             {
-                LogDebug( ( "_handleMsgType failed %d", pktStatus ) );
+                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1313,7 +1313,7 @@ CellularPktStatus_t _Cellular_PktioInit( CellularContext_t * pContext,
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
-        LogDebug( ( "Thread create: read_thread status:%d", pktStatus ) );
+        LogDebug( ( "Thread create: read_thread status:%"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
     }
     else
     {
@@ -1427,7 +1427,7 @@ uint32_t _Cellular_PktioSendData( CellularContext_t * pContext,
                                             dataLen, CELLULAR_COMM_IF_SEND_TIMEOUT_MS, &sentLen );
     }
 
-    LogDebug( ( "PktioSendData sent %d bytes", sentLen ) );
+    LogDebug( ( "PktioSendData sent %"CELLULAR_LOG_FMT_INT32" bytes", sentLen ) );
     return sentLen;
 }
 

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -142,7 +142,7 @@ static void _saveData( char * pLine,
 
     ( void ) dataLen;
 
-    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR" with length %"CELLULAR_LOG_FMT_INT32"", pLine, dataLen ) );
+    LogDebug( ( "_saveData : Save data %"CELLULAR_LOG_FMT_PTR" with length %"CELLULAR_LOG_FMT_UINT32"", pLine, dataLen ) );
 
     pNew = ( CellularATCommandLine_t * ) Platform_Malloc( sizeof( CellularATCommandLine_t ) );
     configASSERT( ( pNew != NULL ) );
@@ -174,7 +174,7 @@ static void _saveRawData( char * pLine,
                           CellularATCommandResponse_t * pResp,
                           uint32_t dataLen )
 {
-    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_PTR"] %"CELLULAR_LOG_FMT_INT32" data to pResp", pLine, dataLen ) );
+    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_PTR"] %"CELLULAR_LOG_FMT_UINT32" data to pResp", pLine, dataLen ) );
     _saveData( pLine, pResp, dataLen );
 }
 
@@ -183,7 +183,7 @@ static void _saveRawData( char * pLine,
 static void _saveATData( char * pLine,
                          CellularATCommandResponse_t * pResp )
 {
-    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_STR"] %"CELLULAR_LOG_FMT_UINT32" AT data to pResp", pLine, strlen( pLine ) ) );
+    LogDebug( ( "Save [%"CELLULAR_LOG_FMT_STR"] %"CELLULAR_LOG_FMT_SIZE" AT data to pResp", pLine, strlen( pLine ) ) );
     _saveData( pLine, pResp, ( uint32_t ) ( strlen( pLine ) + 1U ) );
 }
 
@@ -207,7 +207,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT32", previous line %"CELLULAR_LOG_FMT_STR"",
+                LogError( ( "CELLULAR_AT_WO_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT", previous line %"CELLULAR_LOG_FMT_STR"",
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -226,7 +226,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
             {
                 /* We already have an intermediate response. */
                 pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
-                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT32", previous line %"CELLULAR_LOG_FMT_STR"",
+                LogError( ( "CELLULAR_AT_WITH_PREFIX process intermediate response ERROR: %"CELLULAR_LOG_FMT_STR", status: %"CELLULAR_LOG_FMT_INT", previous line %"CELLULAR_LOG_FMT_STR"",
                             pLine, pkStatus, pResp->pItm->pLine ) );
             }
 
@@ -264,7 +264,7 @@ static CellularPktStatus_t _processIntermediateResponse( char * pLine,
 
         default:
             /* Unexpected message received when sending the AT command. */
-            LogInfo( ( "Undefind message received %"CELLULAR_LOG_FMT_STR" when sending AT command type %"CELLULAR_LOG_FMT_INT32".",
+            LogInfo( ( "Undefind message received %"CELLULAR_LOG_FMT_STR" when sending AT command type %"CELLULAR_LOG_FMT_INT".",
                        pLine, atType ) );
 
             pkStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
@@ -546,7 +546,7 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     /* Move the leftover data or AT command response to the start of buffer.
      * Set the pRead pointer to the empty buffer space. */
 
-    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR" to %"CELLULAR_LOG_FMT_PTR" %"CELLULAR_LOG_FMT_INT32"",
+    LogDebug( ( "moved the partial line/data from %"CELLULAR_LOG_FMT_PTR" to %"CELLULAR_LOG_FMT_PTR" %"CELLULAR_LOG_FMT_UINT32"",
                 pContext->pPktioReadPtr, pContext->pktioReadBuf, pContext->partialDataRcvdLen ) );
 
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
@@ -609,7 +609,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
     if( bufferEmptyLength > 0 )
     {
         ( void ) pContext->pCommIntf->recv( pContext->hPktioCommIntf, ( uint8_t * ) pRead,
-                                            bufferEmptyLength,
+                                            ( uint32_t )bufferEmptyLength,
                                             CELLULAR_COMM_IF_RECV_TIMEOUT_MS, &bytesRead );
 
         if( bytesRead > 0U )
@@ -617,7 +617,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
             /* Add a NULL after the bytesRead. This is required for further processing. */
             pRead[ bytesRead ] = '\0';
 
-            LogDebug( ( "AT Read %"CELLULAR_LOG_FMT_INT32" bytes, data[%"CELLULAR_LOG_FMT_PTR"]", bytesRead, pRead ) );
+            LogDebug( ( "AT Read %"CELLULAR_LOG_FMT_UINT32" bytes, data[%"CELLULAR_LOG_FMT_PTR"]", bytesRead, pRead ) );
             /* Set the pBytesRead only when actual bytes read from comm interface. */
             *pBytesRead = bytesRead + partialDataRead;
 
@@ -670,7 +670,7 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
 
-        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR" start %"CELLULAR_LOG_FMT_PTR" prefix %"CELLULAR_LOG_FMT_INT32" left %"CELLULAR_LOG_FMT_INT32", read total %"CELLULAR_LOG_FMT_INT32"",
+        LogDebug( ( "_handleData : read buffer buffer %"CELLULAR_LOG_FMT_PTR" start %"CELLULAR_LOG_FMT_PTR" prefix %"CELLULAR_LOG_FMT_UINT32" left %"CELLULAR_LOG_FMT_UINT32", read total %"CELLULAR_LOG_FMT_UINT32"",
                     pContext->pktioReadBuf,
                     pStartOfData,
                     bytesBeforeData,
@@ -874,7 +874,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
         else if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             /* Modem returns unexpected response. */
-            LogError( ( "Input buffer callback returns error %"CELLULAR_LOG_FMT_INT32". Clean the read buffer.", pktStatus ) );
+            LogError( ( "Input buffer callback returns error %"CELLULAR_LOG_FMT_INT". Clean the read buffer.", pktStatus ) );
 
             /* Clean the read buffer and read pointer. */
             ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
@@ -954,7 +954,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
+                LogError( ( "pktDataSendPrefixCB returns error %"CELLULAR_LOG_FMT_INT"", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -989,7 +989,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
             }
             else
             {
-                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
+                LogError( ( "pktDataPrefixCB returns error %"CELLULAR_LOG_FMT_INT"", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1131,7 +1131,7 @@ static void _handleAllReceived( CellularContext_t * pContext,
             }
             else
             {
-                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
+                LogDebug( ( "_handleMsgType failed %"CELLULAR_LOG_FMT_INT"", pktStatus ) );
                 keepProcess = false;
             }
         }
@@ -1313,7 +1313,7 @@ CellularPktStatus_t _Cellular_PktioInit( CellularContext_t * pContext,
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
-        LogDebug( ( "Thread create: read_thread status:%"CELLULAR_LOG_FMT_INT32"", pktStatus ) );
+        LogDebug( ( "Thread create: read_thread status:%"CELLULAR_LOG_FMT_INT, pktStatus ) );
     }
     else
     {
@@ -1427,7 +1427,7 @@ uint32_t _Cellular_PktioSendData( CellularContext_t * pContext,
                                             dataLen, CELLULAR_COMM_IF_SEND_TIMEOUT_MS, &sentLen );
     }
 
-    LogDebug( ( "PktioSendData sent %"CELLULAR_LOG_FMT_INT32" bytes", sentLen ) );
+    LogDebug( ( "PktioSendData sent %"CELLULAR_LOG_FMT_UINT32" bytes", sentLen ) );
     return sentLen;
 }
 

--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -453,51 +453,51 @@
 #endif
 
 #ifndef CELLULAR_LOG_FMT_SIZE
-    #define CELLULAR_LOG_FMT_SIZE     "lu"
+    #define CELLULAR_LOG_FMT_SIZE    "lu"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_UINT32
-    #define CELLULAR_LOG_FMT_UINT32     "u"
+    #define CELLULAR_LOG_FMT_UINT32    "u"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_UINT16
-    #define CELLULAR_LOG_FMT_UINT16     "u"
+    #define CELLULAR_LOG_FMT_UINT16    "u"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_UINT8
-    #define CELLULAR_LOG_FMT_UINT8     "u"
+    #define CELLULAR_LOG_FMT_UINT8    "u"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_INT
-    #define CELLULAR_LOG_FMT_INT     "d"
+    #define CELLULAR_LOG_FMT_INT    "d"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_INT32
-    #define CELLULAR_LOG_FMT_INT32     "d"
+    #define CELLULAR_LOG_FMT_INT32    "d"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_INT16
-    #define CELLULAR_LOG_FMT_INT16     "d"
+    #define CELLULAR_LOG_FMT_INT16    "d"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_INT8
-    #define CELLULAR_LOG_FMT_INT8     "d"
+    #define CELLULAR_LOG_FMT_INT8    "d"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_CHAR
-    #define CELLULAR_LOG_FMT_CHAR     "c"
+    #define CELLULAR_LOG_FMT_CHAR    "c"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_STR
-    #define CELLULAR_LOG_FMT_STR     "s"
+    #define CELLULAR_LOG_FMT_STR    "s"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_PTR
-    #define CELLULAR_LOG_FMT_PTR     "p"
+    #define CELLULAR_LOG_FMT_PTR    "p"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_UINT32_HEX
-    #define CELLULAR_LOG_FMT_UINT32_HEX     "x"
+    #define CELLULAR_LOG_FMT_UINT32_HEX    "x"
 #endif
 
 /**

--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -452,6 +452,46 @@
     #define CELLULAR_AT_MAX_STRING_SIZE    ( 256U )
 #endif
 
+#ifndef CELLULAR_LOG_FMT_UINT32
+    #define CELLULAR_LOG_FMT_UINT32     "lu"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_UINT16
+    #define CELLULAR_LOG_FMT_UINT16     "u"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_UINT8
+    #define CELLULAR_LOG_FMT_UINT8     "u"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_INT32
+    #define CELLULAR_LOG_FMT_INT32     "ld"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_INT16
+    #define CELLULAR_LOG_FMT_INT16     "d"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_INT8
+    #define CELLULAR_LOG_FMT_INT8     "d"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_CHAR
+    #define CELLULAR_LOG_FMT_CHAR     "c"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_STR
+    #define CELLULAR_LOG_FMT_STR     "S"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_PTR
+    #define CELLULAR_LOG_FMT_PTR     "P"
+#endif
+
+#ifndef CELLULAR_LOG_FMT_UINT32_HEX
+    #define CELLULAR_LOG_FMT_UINT32_HEX     "x"
+#endif
+
 /**
  * @brief Macro that is called in the cellular library for logging "Error" level
  * messages.

--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -452,8 +452,12 @@
     #define CELLULAR_AT_MAX_STRING_SIZE    ( 256U )
 #endif
 
+#ifndef CELLULAR_LOG_FMT_SIZE
+    #define CELLULAR_LOG_FMT_SIZE     "lu"
+#endif
+
 #ifndef CELLULAR_LOG_FMT_UINT32
-    #define CELLULAR_LOG_FMT_UINT32     "lu"
+    #define CELLULAR_LOG_FMT_UINT32     "u"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_UINT16
@@ -464,8 +468,12 @@
     #define CELLULAR_LOG_FMT_UINT8     "u"
 #endif
 
+#ifndef CELLULAR_LOG_FMT_INT
+    #define CELLULAR_LOG_FMT_INT     "d"
+#endif
+
 #ifndef CELLULAR_LOG_FMT_INT32
-    #define CELLULAR_LOG_FMT_INT32     "ld"
+    #define CELLULAR_LOG_FMT_INT32     "d"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_INT16
@@ -481,11 +489,11 @@
 #endif
 
 #ifndef CELLULAR_LOG_FMT_STR
-    #define CELLULAR_LOG_FMT_STR     "S"
+    #define CELLULAR_LOG_FMT_STR     "s"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_PTR
-    #define CELLULAR_LOG_FMT_PTR     "P"
+    #define CELLULAR_LOG_FMT_PTR     "p"
 #endif
 
 #ifndef CELLULAR_LOG_FMT_UINT32_HEX

--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -452,52 +452,112 @@
     #define CELLULAR_AT_MAX_STRING_SIZE    ( 256U )
 #endif
 
+/**
+ * @brief Cellular log format for size_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "lu"
+ */
 #ifndef CELLULAR_LOG_FMT_SIZE
-    #define CELLULAR_LOG_FMT_SIZE    "lu"
+    #define CELLULAR_LOG_FMT_SIZE           "lu"
 #endif
 
+/**
+ * @brief Cellular log format for uint32_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "u"
+ */
 #ifndef CELLULAR_LOG_FMT_UINT32
-    #define CELLULAR_LOG_FMT_UINT32    "u"
+    #define CELLULAR_LOG_FMT_UINT32         "u"
 #endif
 
+/**
+ * @brief Cellular log format for uint16_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "u"
+ */
 #ifndef CELLULAR_LOG_FMT_UINT16
-    #define CELLULAR_LOG_FMT_UINT16    "u"
+    #define CELLULAR_LOG_FMT_UINT16         "u"
 #endif
 
+/**
+ * @brief Cellular log format for uint8_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "u"
+ */
 #ifndef CELLULAR_LOG_FMT_UINT8
-    #define CELLULAR_LOG_FMT_UINT8    "u"
+    #define CELLULAR_LOG_FMT_UINT8          "u"
 #endif
 
+/**
+ * @brief Cellular log format for int.<br>
+ *
+ * <b>Default value (if undefined):</b> "d"
+ */
 #ifndef CELLULAR_LOG_FMT_INT
-    #define CELLULAR_LOG_FMT_INT    "d"
+    #define CELLULAR_LOG_FMT_INT            "d"
 #endif
 
+/**
+ * @brief Cellular log format for int32_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "d"
+ */
 #ifndef CELLULAR_LOG_FMT_INT32
-    #define CELLULAR_LOG_FMT_INT32    "d"
+    #define CELLULAR_LOG_FMT_INT32          "d"
 #endif
 
+/**
+ * @brief Cellular log format for int16_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "d"
+ */
 #ifndef CELLULAR_LOG_FMT_INT16
-    #define CELLULAR_LOG_FMT_INT16    "d"
+    #define CELLULAR_LOG_FMT_INT16          "d"
 #endif
 
+/**
+ * @brief Cellular log format for int8_t.<br>
+ *
+ * <b>Default value (if undefined):</b> "d"
+ */
 #ifndef CELLULAR_LOG_FMT_INT8
-    #define CELLULAR_LOG_FMT_INT8    "d"
+    #define CELLULAR_LOG_FMT_INT8           "d"
 #endif
 
+/**
+ * @brief Cellular log format for char.<br>
+ *
+ * <b>Default value (if undefined):</b> "d"
+ */
 #ifndef CELLULAR_LOG_FMT_CHAR
-    #define CELLULAR_LOG_FMT_CHAR    "c"
+    #define CELLULAR_LOG_FMT_CHAR           "c"
 #endif
 
+/**
+ * @brief Cellular log format for string.<br>
+ *
+ * <b>Default value (if undefined):</b> "s"
+ */
 #ifndef CELLULAR_LOG_FMT_STR
-    #define CELLULAR_LOG_FMT_STR    "s"
+    #define CELLULAR_LOG_FMT_STR            "s"
 #endif
 
+/**
+ * @brief Cellular log format for pointer.<br>
+ *
+ * <b>Default value (if undefined):</b> "p"
+ */
 #ifndef CELLULAR_LOG_FMT_PTR
-    #define CELLULAR_LOG_FMT_PTR    "p"
+    #define CELLULAR_LOG_FMT_PTR            "p"
 #endif
 
+/**
+ * @brief Cellular log format for uint32_t in hex.<br>
+ *
+ * <b>Default value (if undefined):</b> "x"
+ */
 #ifndef CELLULAR_LOG_FMT_UINT32_HEX
-    #define CELLULAR_LOG_FMT_UINT32_HEX    "x"
+    #define CELLULAR_LOG_FMT_UINT32_HEX     "x"
 #endif
 
 /**

--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -458,7 +458,7 @@
  * <b>Default value (if undefined):</b> "lu"
  */
 #ifndef CELLULAR_LOG_FMT_SIZE
-    #define CELLULAR_LOG_FMT_SIZE           "lu"
+    #define CELLULAR_LOG_FMT_SIZE    "lu"
 #endif
 
 /**
@@ -467,7 +467,7 @@
  * <b>Default value (if undefined):</b> "u"
  */
 #ifndef CELLULAR_LOG_FMT_UINT32
-    #define CELLULAR_LOG_FMT_UINT32         "u"
+    #define CELLULAR_LOG_FMT_UINT32    "u"
 #endif
 
 /**
@@ -476,7 +476,7 @@
  * <b>Default value (if undefined):</b> "u"
  */
 #ifndef CELLULAR_LOG_FMT_UINT16
-    #define CELLULAR_LOG_FMT_UINT16         "u"
+    #define CELLULAR_LOG_FMT_UINT16    "u"
 #endif
 
 /**
@@ -485,7 +485,7 @@
  * <b>Default value (if undefined):</b> "u"
  */
 #ifndef CELLULAR_LOG_FMT_UINT8
-    #define CELLULAR_LOG_FMT_UINT8          "u"
+    #define CELLULAR_LOG_FMT_UINT8    "u"
 #endif
 
 /**
@@ -494,7 +494,7 @@
  * <b>Default value (if undefined):</b> "d"
  */
 #ifndef CELLULAR_LOG_FMT_INT
-    #define CELLULAR_LOG_FMT_INT            "d"
+    #define CELLULAR_LOG_FMT_INT    "d"
 #endif
 
 /**
@@ -503,7 +503,7 @@
  * <b>Default value (if undefined):</b> "d"
  */
 #ifndef CELLULAR_LOG_FMT_INT32
-    #define CELLULAR_LOG_FMT_INT32          "d"
+    #define CELLULAR_LOG_FMT_INT32    "d"
 #endif
 
 /**
@@ -512,7 +512,7 @@
  * <b>Default value (if undefined):</b> "d"
  */
 #ifndef CELLULAR_LOG_FMT_INT16
-    #define CELLULAR_LOG_FMT_INT16          "d"
+    #define CELLULAR_LOG_FMT_INT16    "d"
 #endif
 
 /**
@@ -521,7 +521,7 @@
  * <b>Default value (if undefined):</b> "d"
  */
 #ifndef CELLULAR_LOG_FMT_INT8
-    #define CELLULAR_LOG_FMT_INT8           "d"
+    #define CELLULAR_LOG_FMT_INT8    "d"
 #endif
 
 /**
@@ -530,7 +530,7 @@
  * <b>Default value (if undefined):</b> "d"
  */
 #ifndef CELLULAR_LOG_FMT_CHAR
-    #define CELLULAR_LOG_FMT_CHAR           "c"
+    #define CELLULAR_LOG_FMT_CHAR    "c"
 #endif
 
 /**
@@ -539,7 +539,7 @@
  * <b>Default value (if undefined):</b> "s"
  */
 #ifndef CELLULAR_LOG_FMT_STR
-    #define CELLULAR_LOG_FMT_STR            "s"
+    #define CELLULAR_LOG_FMT_STR    "s"
 #endif
 
 /**
@@ -548,7 +548,7 @@
  * <b>Default value (if undefined):</b> "p"
  */
 #ifndef CELLULAR_LOG_FMT_PTR
-    #define CELLULAR_LOG_FMT_PTR            "p"
+    #define CELLULAR_LOG_FMT_PTR    "p"
 #endif
 
 /**
@@ -557,7 +557,7 @@
  * <b>Default value (if undefined):</b> "x"
  */
 #ifndef CELLULAR_LOG_FMT_UINT32_HEX
-    #define CELLULAR_LOG_FMT_UINT32_HEX     "x"
+    #define CELLULAR_LOG_FMT_UINT32_HEX    "x"
 #endif
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Log format is different for different compiler.
For example, the following code can be compiled with GCC 32 bits and 64 bits. 
```
uint32_t sentLen = 0;
LogDebug( ( "PktioSendData sent %u bytes", sentLen ) );
```
However, there will be format warning with GNU arm compiler.
```
FreeRTOS-Cellular-Interface/source/cellular_pktio.c:1430:17: error: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
 1430 |     LogDebug( ( "PktioSendData sent %u bytes", sentLen ) );
      |                 ^~~~~~~~~~~~~~~~~~~~~~         ~~~~~~~
      |                                                |
      |                                                uint32_t {aka long unsigned int}
```

Although C99 defines inttypes.h for this problem, this library doesn't reply on inttypes.h.

In this PR,
* The following log format configs are defined for different compiler
  * CELLULAR_LOG_FMT_UINT32_HEX
  * CELLULAR_LOG_FMT_UINT32
  * CELLULAR_LOG_FMT_UINT16
  * CELLULAR_LOG_FMT_UINT8
  * CELLULAR_LOG_FMT_INT32
  * CELLULAR_LOG_FMT_INT16
  * CELLULAR_LOG_FMT_INT8
  * CELLULAR_LOG_FMT_PTR
  * CELLULAR_LOG_FMT_STR
  * CELLULAR_LOG_FMT_SIZE
  * CELLULAR_LOG_FMT_CHAR

User with GNU ARM compiler can define the following in celllular_config.h
```
#define CELLULAR_LOG_FMT_SIZE "u"
#define CELLULAR_LOG_FMT_UINT32 "lu"
#define CELLULAR_LOG_FMT_INT32 "ld"
```
Or using PRIx macros if inttypes.h is preferred
```
#include <inttypes.h>

#define CELLULAR_LOG_FMT_SIZE PRIu16
#define CELLULAR_LOG_FMT_UINT32 PRIu32
#define CELLULAR_LOG_FMT_INT32 PRIi32
```

Test Steps
-----------
Reference this branch https://github.com/chinglee-iot/FreeRTOS-Cellular-Interface/tree/add-compiler-warning-check
**GCC** 
Build with the following command.
```
cmake -S test -B build -DCMAKE_C_COMPILER_WORKS=1
cd build
make compilation_test
```

**GNU arm**
Add the following config in test/unit-test/configs/compilation-test/cellular_config.h
```
#define CELLULAR_LOG_FMT_SIZE "u"
#define CELLULAR_LOG_FMT_UINT32 "lu"
#define CELLULAR_LOG_FMT_INT32 "ld"
```
Build with the following command.
```
CC=arm-none-eabi-gcc cmake -B build -S test -DCMAKE_C_COMPILER_WORKS=1
cd build
make compilation_test
```


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#151 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
