### PR TITLE
Fix log print format warning for GNU ARM compiler

### DIFF
--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -489,7 +489,7 @@ static CellularPktStatus_t _parseTimeZoneInfo( char * pTimeZoneResp,
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
-        LogDebug( ( "TimeZoneInfo: Timezone %d Year %d Month %d day %d,", pTimeInfo->timeZone,
+        LogDebug( ( "TimeZoneInfo: Timezone %d Year %d Month %d day %d,", ( int ) pTimeInfo->timeZone,
                     pTimeInfo->year,
                     pTimeInfo->month,
                     pTimeInfo->day ) );

--- a/source/cellular_at_core.c
+++ b/source/cellular_at_core.c
@@ -661,7 +661,7 @@ CellularATError_t Cellular_ATHexStrToHex( const char * pString,
             }
             else
             {
-                firstNibble = firstNibble << 4;
+                firstNibble = ( uint8_t ) ( firstNibble << 4 );
                 ( pHexData )[ i ] = firstNibble | secondNibble;
             }
 

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -599,7 +599,7 @@ CellularError_t _Cellular_RemoveSocketData( CellularContext_t * pContext,
 
     if( socketHandle->socketState == SOCKETSTATE_CONNECTING )
     {
-        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%u]", socketHandle->socketId ) );
+        LogWarn( ( "_Cellular_RemoveSocket, socket is connecting state [%u]", ( unsigned int ) socketHandle->socketId ) );
     }
 
     taskENTER_CRITICAL();
@@ -652,7 +652,7 @@ CellularError_t _Cellular_IsValidSocket( const CellularContext_t * pContext,
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %u", sockIndex ) );
+            LogError( ( "_Cellular_IsValidSocket, invalid socket handle %u", ( unsigned int ) sockIndex ) );
             cellularStatus = CELLULAR_BAD_PARAMETER;
         }
     }
@@ -701,7 +701,7 @@ CellularError_t _Cellular_ConvertCsqSignalRssi( int16_t csqRssi,
         }
         else
         {
-            rssiValue = SIGNAL_QUALITY_CSQ_RSSI_BASE + ( csqRssi * SIGNAL_QUALITY_CSQ_RSSI_STEP );
+            rssiValue = ( int16_t ) ( SIGNAL_QUALITY_CSQ_RSSI_BASE + ( csqRssi * SIGNAL_QUALITY_CSQ_RSSI_STEP ) );
         }
     }
 
@@ -916,7 +916,7 @@ CellularSocketContext_t * _Cellular_GetSocketData( const CellularContext_t * pCo
     {
         if( ( sockIndex >= CELLULAR_NUM_SOCKET_MAX ) || ( pContext->pSocketData[ sockIndex ] == NULL ) )
         {
-            LogError( ( "_Cellular_GetSocketData, invalid socket handle %u", sockIndex ) );
+            LogError( ( "_Cellular_GetSocketData, invalid socket handle %u", ( unsigned int ) sockIndex ) );
         }
         else
         {

--- a/source/cellular_common_api.c
+++ b/source/cellular_common_api.c
@@ -107,8 +107,8 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %d or length %d is invalid.",
-                        socketHandle->socketState, optionValueLength ) );
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the contextID in this state %d or length %u is invalid.",
+                        socketHandle->socketState, ( unsigned int ) optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
     }
@@ -123,8 +123,8 @@ static CellularError_t _socketSetSockOptLevelTransport( CellularSocketOption_t o
         }
         else
         {
-            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %d or length %d is invalid.",
-                        socketHandle->socketState, optionValueLength ) );
+            LogError( ( "Cellular_SocketSetSockOpt: Cannot change the localPort in this state %d or length %u is invalid.",
+                        socketHandle->socketState, ( unsigned int ) optionValueLength ) );
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
     }

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -820,7 +820,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
             if( result >= 0 )
             {
-                LogError( ( "AtParseFail for %u: %d %s %s", i, result,
+                LogError( ( "AtParseFail for %u: %d %s %s", ( unsigned int ) i, ( int ) result,
                             pTokenMap[ i ].pStrValue, pTokenMap[ i + 1U ].pStrValue ) );
                 finit = false;
             }
@@ -836,7 +836,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
 
         for( i = 0; i < tokenMapSize; i++ )
         {
-            LogDebug( ( "Callbacks setup for %u : %s", i, pTokenMap[ i ].pStrValue ) );
+            LogDebug( ( "Callbacks setup for %u : %s", ( unsigned int ) i, pTokenMap[ i ].pStrValue ) );
         }
     }
     else

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -142,7 +142,7 @@ static void _saveData( char * pLine,
 
     ( void ) dataLen;
 
-    LogDebug( ( "_saveData : Save data %p with length %d", pLine, dataLen ) );
+    LogDebug( ( "_saveData : Save data %p with length %u", pLine, ( unsigned int ) dataLen ) );
 
     pNew = ( CellularATCommandLine_t * ) Platform_Malloc( sizeof( CellularATCommandLine_t ) );
     configASSERT( ( pNew != NULL ) );
@@ -174,7 +174,7 @@ static void _saveRawData( char * pLine,
                           CellularATCommandResponse_t * pResp,
                           uint32_t dataLen )
 {
-    LogDebug( ( "Save [%p] %d data to pResp", pLine, dataLen ) );
+    LogDebug( ( "Save [%p] %u data to pResp", pLine, ( unsigned int ) dataLen ) );
     _saveData( pLine, pResp, dataLen );
 }
 
@@ -183,7 +183,7 @@ static void _saveRawData( char * pLine,
 static void _saveATData( char * pLine,
                          CellularATCommandResponse_t * pResp )
 {
-    LogDebug( ( "Save [%s] %lu AT data to pResp", pLine, strlen( pLine ) ) );
+    LogDebug( ( "Save [%s] %u AT data to pResp", pLine, ( unsigned int ) strlen( pLine ) ) );
     _saveData( pLine, pResp, ( uint32_t ) ( strlen( pLine ) + 1U ) );
 }
 
@@ -546,8 +546,8 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     /* Move the leftover data or AT command response to the start of buffer.
      * Set the pRead pointer to the empty buffer space. */
 
-    LogDebug( ( "moved the partial line/data from %p to %p %d",
-                pContext->pPktioReadPtr, pContext->pktioReadBuf, pContext->partialDataRcvdLen ) );
+    LogDebug( ( "moved the partial line/data from %p to %p %u",
+                pContext->pPktioReadPtr, pContext->pktioReadBuf, ( unsigned int ) pContext->partialDataRcvdLen ) );
 
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
     pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] = '\0';
@@ -609,7 +609,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
     if( bufferEmptyLength > 0 )
     {
         ( void ) pContext->pCommIntf->recv( pContext->hPktioCommIntf, ( uint8_t * ) pRead,
-                                            bufferEmptyLength,
+                                            ( uint32_t ) bufferEmptyLength,
                                             CELLULAR_COMM_IF_RECV_TIMEOUT_MS, &bytesRead );
 
         if( bytesRead > 0U )
@@ -617,7 +617,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
             /* Add a NULL after the bytesRead. This is required for further processing. */
             pRead[ bytesRead ] = '\0';
 
-            LogDebug( ( "AT Read %d bytes, data[%p]", bytesRead, pRead ) );
+            LogDebug( ( "AT Read %u bytes, data[%p]", ( unsigned int ) bytesRead, pRead ) );
             /* Set the pBytesRead only when actual bytes read from comm interface. */
             *pBytesRead = bytesRead + partialDataRead;
 
@@ -670,12 +670,12 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
 
-        LogDebug( ( "_handleData : read buffer buffer %p start %p prefix %d left %d, read total %d",
+        LogDebug( ( "_handleData : read buffer buffer %p start %p prefix %d left %d, read total %u",
                     pContext->pktioReadBuf,
                     pStartOfData,
-                    bytesBeforeData,
-                    *pBytesLeft,
-                    bytesRead ) );
+                    ( unsigned int ) bytesBeforeData,
+                    ( unsigned int ) *pBytesLeft,
+                    ( unsigned int ) bytesRead ) );
 
         /* reset the data related variables. */
         pContext->dataLength = 0U;
@@ -886,7 +886,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
         {
             /* The input buffer callback returns incorrect buffer length. */
             LogError( ( "Input buffer callback returns bufferLength %u. Modem returns length %u. Clean the read buffer.",
-                        bufferLength, *pBytesRead ) );
+                        ( unsigned int ) bufferLength, ( unsigned int ) *pBytesRead ) );
 
             /* Clean the read buffer and read pointer. */
             ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
@@ -1026,7 +1026,7 @@ static bool _handleDataResult( CellularContext_t * pContext,
     else
     {
         *pBytesRead = bytesLeft;
-        LogDebug( ( "_handleData okay, keep processing %u bytes %p", bytesLeft, *ppLine ) );
+        LogDebug( ( "_handleData okay, keep processing %u bytes %p", ( unsigned int ) bytesLeft, *ppLine ) );
     }
 
     return keepProcess;
@@ -1427,7 +1427,7 @@ uint32_t _Cellular_PktioSendData( CellularContext_t * pContext,
                                             dataLen, CELLULAR_COMM_IF_SEND_TIMEOUT_MS, &sentLen );
     }
 
-    LogDebug( ( "PktioSendData sent %d bytes", sentLen ) );
+    LogDebug( ( "PktioSendData sent %u bytes", ( unsigned int ) sentLen ) );
     return sentLen;
 }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
* Fix the compilation warning of GNU ARM compiler.


Test Steps
-----------
Reference this branch https://github.com/chinglee-iot/FreeRTOS-Cellular-Interface/tree/add-compiler-warning-check
**GCC** 
Build with the following command should not have error.
```
cmake -S test -B build -DCMAKE_C_COMPILER_WORKS=1
cd build
make compilation_test
```

**GNU arm**
Build with the following command should not have error.
```
CC=arm-none-eabi-gcc cmake -B build -S test -DCMAKE_C_COMPILER_WORKS=1
cd build
make compilation_test
```


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#150 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
