### PR TITLE
Fix _Cellular_AtcmdDataSend interDelayMS

### DIFF
--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -68,8 +68,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
                                                                          uint32_t timeoutMS );
 static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContext_t * pContext,
                                                                   CellularAtDataReq_t dataReq,
-                                                                  uint32_t timeoutMs,
-                                                                  uint32_t interDelayMS );
+                                                                  uint32_t timeoutMs );
 static void _Cellular_PktHandlerAcquirePktRequestMutex( CellularContext_t * pContext );
 static void _Cellular_PktHandlerReleasePktRequestMutex( CellularContext_t * pContext );
 static int _searchCompareFunc( const void * pInputToken,
@@ -267,8 +266,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
 
 static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContext_t * pContext,
                                                                   CellularAtDataReq_t dataReq,
-                                                                  uint32_t timeoutMs,
-                                                                  uint32_t interDelayMS )
+                                                                  uint32_t timeoutMs )
 {
     CellularPktStatus_t respCode = CELLULAR_PKT_STATUS_OK;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
@@ -709,7 +707,7 @@ CellularPktStatus_t _Cellular_AtcmdDataSend( CellularContext_t * pContext,
                 Platform_Delay( interDelayMS );
             }
 
-            pktStatus = _Cellular_DataSendWithTimeoutDelayRaw( pContext, dataReq, dataTimeoutMS, interDelayMS );
+            pktStatus = _Cellular_DataSendWithTimeoutDelayRaw( pContext, dataReq, dataTimeoutMS );
         }
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
@@ -766,7 +764,7 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataSendSuccessToken( CellularContext_
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
-            pktStatus = _Cellular_DataSendWithTimeoutDelayRaw( pContext, dataReq, dataTimeoutMS, 0U );
+            pktStatus = _Cellular_DataSendWithTimeoutDelayRaw( pContext, dataReq, dataTimeoutMS );
         }
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -299,9 +299,6 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         }
     }
 
-    /* Some driver required wait for a minimum of delay before sending data. */
-    Platform_Delay( interDelayMS );
-
     /* End pattern for specific modem. */
     if( ( pktStatus == CELLULAR_PKT_STATUS_OK ) && ( dataReq.pEndPattern != NULL ) )
     {
@@ -706,6 +703,12 @@ CellularPktStatus_t _Cellular_AtcmdDataSend( CellularContext_t * pContext,
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
+            if( interDelayMS > 0U )
+            {
+                /* Some drivers require a minimum delay before sending data. */
+                Platform_Delay( interDelayMS );
+            }
+
             pktStatus = _Cellular_DataSendWithTimeoutDelayRaw( pContext, dataReq, dataTimeoutMS, interDelayMS );
         }
 

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -705,7 +705,7 @@ CellularPktStatus_t _Cellular_AtcmdDataSend( CellularContext_t * pContext,
         {
             if( interDelayMS > 0U )
             {
-                /* Some drivers require a minimum delay before sending data. */
+                /* Cellular modem may require a minimum delay before sending data. */
                 Platform_Delay( interDelayMS );
             }
 


### PR DESCRIPTION
Fix the inter delay for _Cellular_AtcmdDataSend

<!--- Title -->

Description
-----------
`interDelayMS` is designed to adapt the behavior of cellular modem that a minimum delay is required before sending data.

For example, after the `@` prompt reception, SARA-R4 AT command `+USOWR` requires the cellular library to wait for a minimum 50ms before sending data.

The delay should happen after data send command success but before sending data. This PR fix the interDelayMS.

* Move the delay to code between the data send command success and sending data.

Test Steps
-----------
Running SARA-R4 demo without problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
