### PR TITLE
Fix decihours to 6 minutes and add UT to test active timer value.

### DIFF
--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1589,7 +1589,7 @@ static CellularATError_t parseT3324TimerValue( char * pToken,
         switch( timerUnitIndex )
         {
             case T3324_TIMER_UNIT_2SECONDS:
-                *pTimerValueSeconds = timerValue * 2u;
+                *pTimerValueSeconds = timerValue * 2U;
                 break;
 
             case T3324_TIMER_UNIT_1MINUTE:
@@ -1597,7 +1597,7 @@ static CellularATError_t parseT3324TimerValue( char * pToken,
                 break;
 
             case T3324_TIMER_UNIT_DECIHOURS:
-                *pTimerValueSeconds = timerValue * ( 15U * 60U );
+                *pTimerValueSeconds = timerValue * ( 6U * 60U );
                 break;
 
             case T3324_TIMER_UNIT_DEACTIVATED:


### PR DESCRIPTION
<!--- Title -->
Fix decihours to 6 minutes and add UT to test active timer value.

Description
-----------
<!--- Describe your changes in detail. -->
As [FreeRTOS forum issue](https://forums.freertos.org/t/timer-t3324-in-freertos-cellular-interface-library/18456/2) mentioned, decihours is 6 minutes, not 15 minutes.

Change includes:
- Change T3324 timer value of decihours from 15 minutes to 6 minutes.
- Add UT test cases to check T3324 timer value.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Pass UT new test cases.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
