### PR TITLE
Add CELLULAR_CONFIG_USE_CCID_COMMAND config for ICCID

### DIFF
--- a/source/include/cellular_config_defaults.h
+++ b/source/include/cellular_config_defaults.h
@@ -453,6 +453,18 @@
 #endif
 
 /**
+ * @brief Use AT+CCID command for Integrated Circuit Card ID( ICCID ) information.<br>
+ *
+ * Acquire ICCID with non-standard 3GPP command AT+CCID in Cellular_CommonGetSimCardInfo.<br>
+ *
+ * <b>Possible values:</b>`0 or 1`<br>
+ * <b>Default value (if undefined):</b> 1
+ */
+#ifndef CELLULAR_CONFIG_USE_CCID_COMMAND
+    #define CELLULAR_CONFIG_USE_CCID_COMMAND    1
+#endif
+
+/**
  * @brief Macro that is called in the cellular library for logging "Error" level
  * messages.
  *


### PR DESCRIPTION

<!--- Title -->

Description
-----------
Feedback from forum AT+CCID is not 3GPP standard AT command. However, it is supported by many existing port including SARA-R4 and HL7802. Add this config to consider in backward compatibility. New port can still use proprietary AT command to get ICCID information and `Cellular_CommonGetSimCardInfo` for the rest in `CellularSimCardInfo_t`.

* Add config `CELLULAR_CONFIG_USE_CCID_COMMAND` to use non-standard AT command "AT+CCID" for ICCID information in `Cellular_CommonGetSimCardInfo`.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
