### PR TITLE
Set to numeric format in atcmdUpdateMccMnc

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>cellular_3gpp_api.c</td>
-        <td><center>6.4K</center></td>
+        <td><center>6.5K</center></td>
         <td><center>5.9K</center></td>
     </tr>
     <tr>
@@ -44,7 +44,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>15.0K</center></b></td>
+        <td><b><center>15.1K</center></b></td>
         <td><b><center>13.6K</center></b></td>
     </tr>
 </table>

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1421,7 +1421,7 @@ static CellularError_t atcmdUpdateMccMnc( CellularContext_t * pContext,
     /* Set the response to numeric format. */
     atCopsRequest.pAtCmd = "AT+COPS=3,2",
     atCopsRequest.atCmdType = CELLULAR_AT_NO_RESULT,
-    pktStatus =  _Cellular_AtcmdRequestWithCallback( pContext, atCopsRequest );
+    pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atCopsRequest );
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {

--- a/test/unit-test/cellular_3gpp_api_utest.c
+++ b/test/unit-test/cellular_3gpp_api_utest.c
@@ -195,6 +195,7 @@ CellularPktStatus_t Mock_AtcmdRequestWithCallback( CellularContext_t * pContext,
                                                    int cmock_num_calls )
 {
     cellularOperatorInfo_t * pOperatorInfo;
+
     ( void ) pContext;
 
     if( cmock_num_calls == 0 )
@@ -2070,7 +2071,9 @@ void test_Cellular_CommonGetRegisteredNetwork_Set_Numeric_Format_Fail( void )
     CellularPlmnInfo_t networkInfo;
 
     _Cellular_CheckLibraryStatus_IgnoreAndReturn( CELLULAR_SUCCESS );
-    _Cellular_AtcmdRequestWithCallback_IgnoreAndReturn( CELLULAR_INTERNAL_FAILURE );
+    _Cellular_AtcmdRequestWithCallback_IgnoreAndReturn( CELLULAR_PKT_STATUS_FAILURE );
+    _Cellular_TranslatePktStatus_ExpectAndReturn( CELLULAR_PKT_STATUS_FAILURE, CELLULAR_INTERNAL_FAILURE );
+
     cellularStatus = Cellular_CommonGetRegisteredNetwork( cellularHandle, &networkInfo );
     TEST_ASSERT_EQUAL( CELLULAR_INTERNAL_FAILURE, cellularStatus );
 }


### PR DESCRIPTION
Set to numeric format in atcmdUpdateMccMnc

Description
-----------
* In order not to rely on port initialization. Set to numeric format to acquire MCC and MNC information in atcmdUpdateMccMnc.

Test Steps
-----------
Remove the port initialize AT command "AT+COPS=3,2". The MCC and MNC can't be acquired with `Cellular_CommonGetRegisteredNetwork` correctly.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
