### PR TITLE
Update Cellular_CommonInit error handling

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -25,7 +25,7 @@
     <tr>
         <td>cellular_common_api.c</td>
         <td><center>0.7K</center></td>
-        <td><center>0.6K</center></td>
+        <td><center>0.7K</center></td>
     </tr>
     <tr>
         <td>cellular_common.c</td>
@@ -45,6 +45,6 @@
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>15.1K</center></b></td>
-        <td><b><center>13.6K</center></b></td>
+        <td><b><center>13.7K</center></b></td>
     </tr>
 </table>

--- a/test/cbmc/proofs/Cellular_CommonInit/Cellular_CommonInit_harness.c
+++ b/test/cbmc/proofs/Cellular_CommonInit/Cellular_CommonInit_harness.c
@@ -96,5 +96,7 @@ void harness()
     * Initialize the member of Cellular_CommonInit.
     ****************************************************************/
 
-    Cellular_CommonInit( nondet_bool() ? NULL : &pHandle, &CellularCommInterface, &tokenTable );
+    Cellular_CommonInit( nondet_bool() ? NULL : &pHandle,
+                         nondet_bool() ? NULL : &CellularCommInterface,
+                         nondet_bool() ? NULL : &tokenTable );
 }

--- a/test/cbmc/proofs/Cellular_CommonInit/Makefile
+++ b/test/cbmc/proofs/Cellular_CommonInit/Makefile
@@ -24,7 +24,7 @@ HARNESS_ENTRY=harness
 HARNESS_FILE=Cellular_CommonInit_harness
 PROOF_UID = Cellular_CommonInit
 
-DEFINES +=
+DEFINES += -DCBMC_TEST_CELLULAR_MODULE_RETURN_ERROR=1
 INCLUDES +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
@@ -34,5 +34,7 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/cellular_platform.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/cellular_modules.c
 PROJECT_SOURCES += $(SRCDIR)/source/cellular_common_api.c
 PROJECT_SOURCES += $(SRCDIR)/source/cellular_common.c
+
+UNWINDSET += __CPROVER_file_local_cellular_common_c_libClose.0:20
 
 include ../Makefile.common

--- a/test/cbmc/sources/cellular_modules.c
+++ b/test/cbmc/sources/cellular_modules.c
@@ -33,41 +33,64 @@
 /* Include paths for public enums, structures, and macros. */
 #include "cellular_common_portable.h"
 
-CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
-                                     void ** ppModuleContext )
-{
-    CellularError_t ret = nondet_int();
+#if ( CBMC_TEST_CELLULAR_MODULE_RETURN_ERROR == 1 )
 
-    __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
-    return ret;
-}
+    CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
+                                         void ** ppModuleContext )
+    {
+        CellularError_t ret = nondet_int();
 
+        __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
+        return ret;
+    }
 
-CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
-{
-    CellularError_t ret = nondet_int();
+    CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
+    {
+        CellularError_t ret = nondet_int();
 
-    __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
-    return ret;
-}
+        __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
+        return ret;
+    }
 
+    CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
+    {
+        CellularError_t ret = nondet_int();
 
-CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
-{
-    CellularError_t ret = nondet_int();
+        __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
+        return ret;
+    }
 
-    __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
-    return ret;
-}
+    CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
+    {
+        CellularError_t ret = nondet_int();
 
+        __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
+        return ret;
+    }
 
-CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
-{
-    CellularError_t ret = nondet_int();
+#else /* #if ( CBMC_TEST_CELLULAR_MODULE_NO_ERROR == 1 ) */
 
-    __CPROVER_assume( ret >= CELLULAR_SUCCESS && ret <= CELLULAR_UNKNOWN );
-    return ret;
-}
+    CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
+                                         void ** ppModuleContext )
+    {
+        return CELLULAR_SUCCESS;
+    }
 
+    CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
+    {
+        return CELLULAR_SUCCESS;
+    }
+
+    CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
+    {
+        return CELLULAR_SUCCESS;
+    }
+
+    CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
+    {
+        return CELLULAR_SUCCESS;
+    }
+
+#endif /* #if ( CBMC_TEST_CELLULAR_MODULE_NO_ERROR == 1 ) */
 
 /* ========================================================================== */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR address the problem reported in [forum](https://forums.freertos.org/t/cellular-interface-allocated-context-memory-is-leaked-if-cellular-init-fails/18963).

In this PR
* Update Cellular_CommonInit error handling to clean up the cellular interface library if modem port function returns error.

Test Steps
-----------
Before this PR, the following test code will have cellular context leakage.

```c
cellularStatus = Cellular_Init( &pCellularHandle, pCommInterface );
```
`cellularStatus` is not `CELLULAR_SUCCESS` due to any one of the following function returns error
```c
cellularStatus = Cellular_ModuleInit( pContext, &pContext->pModuleContext );
cellularStatus = Cellular_ModuleEnableUE( pContext );
cellularStatus = Cellular_ModuleEnableUrc( pContext );
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
