### PR TITLE
Fix MISRA C 2012 deviations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
+          -DUNITTEST=ON \
           -DBUILD_CLONE_SUBMODULES=ON \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
 

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>cellular_3gpp_api.c</td>
-        <td><center>6.5K</center></td>
+        <td><center>6.4K</center></td>
         <td><center>5.9K</center></td>
     </tr>
     <tr>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td>cellular_pktio.c</td>
-        <td><center>2.2K</center></td>
+        <td><center>2.3K</center></td>
         <td><center>1.9K</center></td>
     </tr>
     <tr>

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -40,11 +40,11 @@
     <tr>
         <td>cellular_pktio.c</td>
         <td><center>2.3K</center></td>
-        <td><center>1.9K</center></td>
+        <td><center>2.0K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>15.1K</center></b></td>
-        <td><b><center>13.7K</center></b></td>
+        <td><b><center>13.8K</center></b></td>
     </tr>
 </table>

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -983,7 +983,7 @@ static bool _parseCopsNetworkNameToken( const char * pToken,
             {
                 ( void ) strncpy( pOperatorInfo->plmnInfo.mcc, pToken, CELLULAR_MCC_MAX_SIZE );
                 pOperatorInfo->plmnInfo.mcc[ CELLULAR_MCC_MAX_SIZE ] = '\0';
-                ( void ) strncpy( pOperatorInfo->plmnInfo.mnc, &( pToken[ CELLULAR_MCC_MAX_SIZE ] ),
+                ( void ) strncpy( pOperatorInfo->plmnInfo.mnc, &pToken[ CELLULAR_MCC_MAX_SIZE ],
                                   ( uint32_t ) ( mccMncLen - CELLULAR_MCC_MAX_SIZE + 1u ) );
                 pOperatorInfo->plmnInfo.mnc[ CELLULAR_MNC_MAX_SIZE ] = '\0';
             }
@@ -1482,7 +1482,7 @@ static CellularError_t atcmdQueryRegStatus( CellularContext_t * pContext,
     /* Get the service status from lib AT data. */
     if( cellularStatus == CELLULAR_SUCCESS )
     {
-        pLibAtData = &( pContext->libAtData );
+        pLibAtData = &pContext->libAtData;
         _Cellular_LockAtDataMutex( pContext );
         pServiceStatus->rat = pLibAtData->rat;
         pServiceStatus->csRegistrationStatus = pLibAtData->csRegStatus;
@@ -2080,7 +2080,7 @@ void _Cellular_DestroyAtDataMutex( CellularContext_t * pContext )
 {
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Destroy( &( pContext->libAtDataMutex ) );
+    PlatformMutex_Destroy( &pContext->libAtDataMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -2091,7 +2091,7 @@ bool _Cellular_CreateAtDataMutex( CellularContext_t * pContext )
 
     configASSERT( pContext != NULL );
 
-    status = PlatformMutex_Create( &( pContext->libAtDataMutex ), false );
+    status = PlatformMutex_Create( &pContext->libAtDataMutex, false );
 
     return status;
 }
@@ -2102,7 +2102,7 @@ void _Cellular_LockAtDataMutex( CellularContext_t * pContext )
 {
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Lock( &( pContext->libAtDataMutex ) );
+    PlatformMutex_Lock( &pContext->libAtDataMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -2111,7 +2111,7 @@ void _Cellular_UnlockAtDataMutex( CellularContext_t * pContext )
 {
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Unlock( &( pContext->libAtDataMutex ) );
+    PlatformMutex_Unlock( &pContext->libAtDataMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -2125,7 +2125,7 @@ void _Cellular_InitAtData( CellularContext_t * pContext,
 
     configASSERT( pContext != NULL );
 
-    pLibAtData = &( pContext->libAtData );
+    pLibAtData = &pContext->libAtData;
 
     if( mode == 0u )
     {
@@ -2690,7 +2690,7 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
         atReqGetSimLockStatus.atCmdType = CELLULAR_AT_WITH_PREFIX;
         atReqGetSimLockStatus.pAtRspPrefix = "+CPIN";
         atReqGetSimLockStatus.respCallback = _Cellular_RecvFuncGetSimLockStatus;
-        atReqGetSimLockStatus.pData = &( pSimCardStatus->simCardLockState );
+        atReqGetSimLockStatus.pData = &pSimCardStatus->simCardLockState;
         atReqGetSimLockStatus.dataLen = ( uint16_t ) sizeof( CellularSimCardLockState_t );
 
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetSimLockStatus );
@@ -2737,7 +2737,7 @@ CellularError_t Cellular_CommonGetSimCardInfo( CellularHandle_t cellularHandle,
     atReqGetHplmn.atCmdType = CELLULAR_AT_WITH_PREFIX;
     atReqGetHplmn.pAtRspPrefix = "+CRSM";
     atReqGetHplmn.respCallback = _Cellular_RecvFuncGetHplmn;
-    atReqGetHplmn.pData = &( pSimCardInfo->plmn );
+    atReqGetHplmn.pData = &pSimCardInfo->plmn;
     atReqGetHplmn.dataLen = ( uint16_t ) sizeof( CellularPlmnInfo_t );
 
     /* pContext is checked in _Cellular_CheckLibraryStatus function. */
@@ -2853,13 +2853,13 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         /* coverity[misra_c_2012_rule_21_6_violation]. */
         ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%d,", pPsmSettings->mode );
         cmdBufLen = ( uint32_t ) strlen( cmdBuf );
-        cmdBufLen = cmdBufLen + appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicRauValue, false );
-        cmdBufLen = cmdBufLen + appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->gprsReadyTimer, false );
-        cmdBufLen = cmdBufLen + appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicTauValue, false );
-        ( void ) appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        ( void ) appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                       pPsmSettings->activeTimeValue, true );
 
         LogDebug( ( "PSM setting: %s ", cmdBuf ) );
@@ -2916,19 +2916,19 @@ static CellularATError_t parseGetPsmToken( char * pToken,
             break;
 
         case CPSMS_POS_RAU:
-            atCoreStatus = parseT3412TimerValue( pToken, &( pPsmSettings->periodicRauValue ) );
+            atCoreStatus = parseT3412TimerValue( pToken, &pPsmSettings->periodicRauValue );
             break;
 
         case CPSMS_POS_RDY_TIMER:
-            atCoreStatus = parseT3324TimerValue( pToken, &( pPsmSettings->gprsReadyTimer ) );
+            atCoreStatus = parseT3324TimerValue( pToken, &pPsmSettings->gprsReadyTimer );
             break;
 
         case CPSMS_POS_TAU:
-            atCoreStatus = parseT3412TimerValue( pToken, &( pPsmSettings->periodicTauValue ) );
+            atCoreStatus = parseT3412TimerValue( pToken, &pPsmSettings->periodicTauValue );
             break;
 
         case CPSMS_POS_ACTIVE_TIME:
-            atCoreStatus = parseT3324TimerValue( pToken, &( pPsmSettings->activeTimeValue ) );
+            atCoreStatus = parseT3324TimerValue( pToken, &pPsmSettings->activeTimeValue );
             break;
 
         default:

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1419,8 +1419,8 @@ static CellularError_t atcmdUpdateMccMnc( CellularContext_t * pContext,
     CellularAtReq_t atCopsRequest = { 0 };
 
     /* Set the response to numeric format. */
-    atCopsRequest.pAtCmd = "AT+COPS=3,2",
-    atCopsRequest.atCmdType = CELLULAR_AT_NO_RESULT,
+    atCopsRequest.pAtCmd = "AT+COPS=3,2";
+    atCopsRequest.atCmdType = CELLULAR_AT_NO_RESULT;
     pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atCopsRequest );
 
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
@@ -1808,7 +1808,7 @@ CellularError_t Cellular_CommonGetRegisteredNetwork( CellularHandle_t cellularHa
     }
     else
     {
-        memset( pOperatorInfo, 0, sizeof( cellularOperatorInfo_t ) );
+        ( void ) memset( pOperatorInfo, 0, sizeof( cellularOperatorInfo_t ) );
         cellularStatus = atcmdUpdateMccMnc( pContext, pOperatorInfo );
     }
 
@@ -2667,14 +2667,7 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
     CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
-    CellularAtReq_t atReqGetSimLockStatus = { 0 };
-
-    atReqGetSimLockStatus.pAtCmd = "AT+CPIN?";
-    atReqGetSimLockStatus.atCmdType = CELLULAR_AT_WITH_PREFIX;
-    atReqGetSimLockStatus.pAtRspPrefix = "+CPIN";
-    atReqGetSimLockStatus.respCallback = _Cellular_RecvFuncGetSimLockStatus;
-    atReqGetSimLockStatus.pData = NULL;
-    atReqGetSimLockStatus.dataLen = 0;
+    CellularAtReq_t atReqGetSimLockStatus;
 
     /* pContext is checked in _Cellular_CheckLibraryStatus function. */
     cellularStatus = _Cellular_CheckLibraryStatus( pContext );
@@ -2693,6 +2686,10 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
         /* Initialize the sim state and the sim lock state. */
         pSimCardStatus->simCardLockState = CELLULAR_SIM_CARD_LOCK_UNKNOWN;
 
+        atReqGetSimLockStatus.pAtCmd = "AT+CPIN?";
+        atReqGetSimLockStatus.atCmdType = CELLULAR_AT_WITH_PREFIX;
+        atReqGetSimLockStatus.pAtRspPrefix = "+CPIN";
+        atReqGetSimLockStatus.respCallback = _Cellular_RecvFuncGetSimLockStatus;
         atReqGetSimLockStatus.pData = &pSimCardStatus->simCardLockState;
         atReqGetSimLockStatus.dataLen = ( uint16_t ) sizeof( CellularSimCardLockState_t );
 

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -983,7 +983,7 @@ static bool _parseCopsNetworkNameToken( const char * pToken,
             {
                 ( void ) strncpy( pOperatorInfo->plmnInfo.mcc, pToken, CELLULAR_MCC_MAX_SIZE );
                 pOperatorInfo->plmnInfo.mcc[ CELLULAR_MCC_MAX_SIZE ] = '\0';
-                ( void ) strncpy( pOperatorInfo->plmnInfo.mnc, &pToken[ CELLULAR_MCC_MAX_SIZE ],
+                ( void ) strncpy( pOperatorInfo->plmnInfo.mnc, &( pToken[ CELLULAR_MCC_MAX_SIZE ] ),
                                   ( uint32_t ) ( mccMncLen - CELLULAR_MCC_MAX_SIZE + 1u ) );
                 pOperatorInfo->plmnInfo.mnc[ CELLULAR_MNC_MAX_SIZE ] = '\0';
             }
@@ -1482,7 +1482,7 @@ static CellularError_t atcmdQueryRegStatus( CellularContext_t * pContext,
     /* Get the service status from lib AT data. */
     if( cellularStatus == CELLULAR_SUCCESS )
     {
-        pLibAtData = &pContext->libAtData;
+        pLibAtData = &( pContext->libAtData );
         _Cellular_LockAtDataMutex( pContext );
         pServiceStatus->rat = pLibAtData->rat;
         pServiceStatus->csRegistrationStatus = pLibAtData->csRegStatus;
@@ -2080,7 +2080,7 @@ void _Cellular_DestroyAtDataMutex( CellularContext_t * pContext )
 {
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Destroy( &pContext->libAtDataMutex );
+    PlatformMutex_Destroy( &( pContext->libAtDataMutex ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -2091,7 +2091,7 @@ bool _Cellular_CreateAtDataMutex( CellularContext_t * pContext )
 
     configASSERT( pContext != NULL );
 
-    status = PlatformMutex_Create( &pContext->libAtDataMutex, false );
+    status = PlatformMutex_Create( &( pContext->libAtDataMutex ), false );
 
     return status;
 }
@@ -2102,7 +2102,7 @@ void _Cellular_LockAtDataMutex( CellularContext_t * pContext )
 {
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Lock( &pContext->libAtDataMutex );
+    PlatformMutex_Lock( &( pContext->libAtDataMutex ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -2111,7 +2111,7 @@ void _Cellular_UnlockAtDataMutex( CellularContext_t * pContext )
 {
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Unlock( &pContext->libAtDataMutex );
+    PlatformMutex_Unlock( &( pContext->libAtDataMutex ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -2125,7 +2125,7 @@ void _Cellular_InitAtData( CellularContext_t * pContext,
 
     configASSERT( pContext != NULL );
 
-    pLibAtData = &pContext->libAtData;
+    pLibAtData = &( pContext->libAtData );
 
     if( mode == 0u )
     {
@@ -2690,7 +2690,7 @@ CellularError_t Cellular_CommonGetSimCardLockStatus( CellularHandle_t cellularHa
         atReqGetSimLockStatus.atCmdType = CELLULAR_AT_WITH_PREFIX;
         atReqGetSimLockStatus.pAtRspPrefix = "+CPIN";
         atReqGetSimLockStatus.respCallback = _Cellular_RecvFuncGetSimLockStatus;
-        atReqGetSimLockStatus.pData = &pSimCardStatus->simCardLockState;
+        atReqGetSimLockStatus.pData = &( pSimCardStatus->simCardLockState );
         atReqGetSimLockStatus.dataLen = ( uint16_t ) sizeof( CellularSimCardLockState_t );
 
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetSimLockStatus );
@@ -2737,7 +2737,7 @@ CellularError_t Cellular_CommonGetSimCardInfo( CellularHandle_t cellularHandle,
     atReqGetHplmn.atCmdType = CELLULAR_AT_WITH_PREFIX;
     atReqGetHplmn.pAtRspPrefix = "+CRSM";
     atReqGetHplmn.respCallback = _Cellular_RecvFuncGetHplmn;
-    atReqGetHplmn.pData = &pSimCardInfo->plmn;
+    atReqGetHplmn.pData = &( pSimCardInfo->plmn );
     atReqGetHplmn.dataLen = ( uint16_t ) sizeof( CellularPlmnInfo_t );
 
     /* pContext is checked in _Cellular_CheckLibraryStatus function. */
@@ -2853,13 +2853,13 @@ CellularError_t Cellular_CommonSetPsmSettings( CellularHandle_t cellularHandle,
         /* coverity[misra_c_2012_rule_21_6_violation]. */
         ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+CPSMS=%d,", pPsmSettings->mode );
         cmdBufLen = ( uint32_t ) strlen( cmdBuf );
-        cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        cmdBufLen = cmdBufLen + appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicRauValue, false );
-        cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        cmdBufLen = cmdBufLen + appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->gprsReadyTimer, false );
-        cmdBufLen = cmdBufLen + appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        cmdBufLen = cmdBufLen + appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                                      pPsmSettings->periodicTauValue, false );
-        ( void ) appendBinaryPattern( &cmdBuf[ cmdBufLen ], ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
+        ( void ) appendBinaryPattern( &( cmdBuf[ cmdBufLen ] ), ( CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen ),
                                       pPsmSettings->activeTimeValue, true );
 
         LogDebug( ( "PSM setting: %s ", cmdBuf ) );
@@ -2916,19 +2916,19 @@ static CellularATError_t parseGetPsmToken( char * pToken,
             break;
 
         case CPSMS_POS_RAU:
-            atCoreStatus = parseT3412TimerValue( pToken, &pPsmSettings->periodicRauValue );
+            atCoreStatus = parseT3412TimerValue( pToken, &( pPsmSettings->periodicRauValue ) );
             break;
 
         case CPSMS_POS_RDY_TIMER:
-            atCoreStatus = parseT3324TimerValue( pToken, &pPsmSettings->gprsReadyTimer );
+            atCoreStatus = parseT3324TimerValue( pToken, &( pPsmSettings->gprsReadyTimer ) );
             break;
 
         case CPSMS_POS_TAU:
-            atCoreStatus = parseT3412TimerValue( pToken, &pPsmSettings->periodicTauValue );
+            atCoreStatus = parseT3412TimerValue( pToken, &( pPsmSettings->periodicTauValue ) );
             break;
 
         case CPSMS_POS_ACTIVE_TIME:
-            atCoreStatus = parseT3324TimerValue( pToken, &pPsmSettings->activeTimeValue );
+            atCoreStatus = parseT3324TimerValue( pToken, &( pPsmSettings->activeTimeValue ) );
             break;
 
         default:

--- a/source/cellular_3gpp_urc_handler.c
+++ b/source/cellular_3gpp_urc_handler.c
@@ -559,7 +559,7 @@ CellularPktStatus_t _Cellular_ParseRegStatus( CellularContext_t * pContext,
     }
     else
     {
-        pLibAtData = &pContext->libAtData;
+        pLibAtData = &( pContext->libAtData );
 
         if( isUrc == true )
         {

--- a/source/cellular_3gpp_urc_handler.c
+++ b/source/cellular_3gpp_urc_handler.c
@@ -559,7 +559,7 @@ CellularPktStatus_t _Cellular_ParseRegStatus( CellularContext_t * pContext,
     }
     else
     {
-        pLibAtData = &( pContext->libAtData );
+        pLibAtData = &pContext->libAtData;
 
         if( isUrc == true )
         {

--- a/source/cellular_at_core.c
+++ b/source/cellular_at_core.c
@@ -330,7 +330,7 @@ CellularATError_t Cellular_ATRemoveTrailingWhiteSpaces( char * pString )
          * when the string length is greater than 2. */
         if( stringLen > 2U )
         {
-            p = &pString[ stringLen ];
+            p = &( pString[ stringLen ] );
 
             do
             {
@@ -571,11 +571,11 @@ CellularATError_t Cellular_ATGetSpecificNextTok( char ** ppString,
 
         if( ( tokStrLen < dataStrlen ) && ( ( *ppString )[ tokStrLen + 1U ] != '\0' ) )
         {
-            *ppString = &tok[ strlen( tok ) + 1U ];
+            *ppString = &( tok[ strlen( tok ) + 1U ] );
         }
         else
         {
-            *ppString = &tok[ strlen( tok ) ];
+            *ppString = &( tok[ strlen( tok ) ] );
         }
 
         *ppTokOutput = tok;
@@ -665,7 +665,7 @@ CellularATError_t Cellular_ATHexStrToHex( const char * pString,
                 ( pHexData )[ i ] = firstNibble | secondNibble;
             }
 
-            p = &p[ 2 ];
+            p = &( p[ 2 ] );
         }
     }
 

--- a/source/cellular_at_core.c
+++ b/source/cellular_at_core.c
@@ -330,7 +330,7 @@ CellularATError_t Cellular_ATRemoveTrailingWhiteSpaces( char * pString )
          * when the string length is greater than 2. */
         if( stringLen > 2U )
         {
-            p = &( pString[ stringLen ] );
+            p = &pString[ stringLen ];
 
             do
             {
@@ -571,11 +571,11 @@ CellularATError_t Cellular_ATGetSpecificNextTok( char ** ppString,
 
         if( ( tokStrLen < dataStrlen ) && ( ( *ppString )[ tokStrLen + 1U ] != '\0' ) )
         {
-            *ppString = &( tok[ strlen( tok ) + 1U ] );
+            *ppString = &tok[ strlen( tok ) + 1U ];
         }
         else
         {
-            *ppString = &( tok[ strlen( tok ) ] );
+            *ppString = &tok[ strlen( tok ) ];
         }
 
         *ppTokOutput = tok;
@@ -665,7 +665,7 @@ CellularATError_t Cellular_ATHexStrToHex( const char * pString,
                 ( pHexData )[ i ] = firstNibble | secondNibble;
             }
 
-            p = &( p[ 2 ] );
+            p = &p[ 2 ];
         }
     }
 

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -126,7 +126,7 @@ static CellularContext_t * _Cellular_AllocContext( void )
         {
             #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 1 )
             {
-                pContext = &( cellularStaticContextTable[ i ] );
+                pContext = &cellularStaticContextTable[ i ];
             }
             #else
             {
@@ -190,7 +190,7 @@ static CellularError_t libOpen( CellularContext_t * pContext )
 
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Lock( &( pContext->libStatusMutex ) );
+    PlatformMutex_Lock( &pContext->libStatusMutex );
 
     ( CellularPktStatus_t ) _Cellular_AtParseInit( pContext );
     _Cellular_LockAtDataMutex( pContext );
@@ -223,7 +223,7 @@ static CellularError_t libOpen( CellularContext_t * pContext )
         pContext->bLibShutdown = false;
     }
 
-    PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
+    PlatformMutex_Unlock( &pContext->libStatusMutex );
 
     return cellularStatus;
 }
@@ -237,12 +237,12 @@ static void libClose( CellularContext_t * pContext )
 
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Lock( &( pContext->libStatusMutex ) );
+    PlatformMutex_Lock( &pContext->libStatusMutex );
     bOpened = pContext->bLibOpened;
 
     /* Indicate that CellularLib is in the process of closing. */
     pContext->bLibClosing = true;
-    PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
+    PlatformMutex_Unlock( &pContext->libStatusMutex );
 
     if( bOpened == true )
     {
@@ -251,7 +251,7 @@ static void libClose( CellularContext_t * pContext )
         _Cellular_PktHandlerCleanup( pContext );
     }
 
-    PlatformMutex_Lock( &( pContext->libStatusMutex ) );
+    PlatformMutex_Lock( &pContext->libStatusMutex );
     pContext->bLibShutdown = false;
     pContext->bLibOpened = false;
     pContext->bLibClosing = false;
@@ -270,7 +270,7 @@ static void libClose( CellularContext_t * pContext )
         }
     }
 
-    PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
+    PlatformMutex_Unlock( &pContext->libStatusMutex );
     LogDebug( ( "CELLULARLib closed" ) );
 }
 
@@ -280,7 +280,7 @@ static bool _Cellular_CreateLibStatusMutex( CellularContext_t * pContext )
 {
     bool status = false;
 
-    status = PlatformMutex_Create( &( pContext->libStatusMutex ), false );
+    status = PlatformMutex_Create( &pContext->libStatusMutex, false );
 
     return status;
 }
@@ -289,7 +289,7 @@ static bool _Cellular_CreateLibStatusMutex( CellularContext_t * pContext )
 
 static void _Cellular_DestroyLibStatusMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Destroy( &( pContext->libStatusMutex ) );
+    PlatformMutex_Destroy( &pContext->libStatusMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -440,19 +440,19 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
     }
     else
     {
-        PlatformMutex_Lock( &( pContext->libStatusMutex ) );
+        PlatformMutex_Lock( &pContext->libStatusMutex );
 
         if( pContext->bLibOpened == false )
         {
             cellularStatus = CELLULAR_LIBRARY_NOT_OPEN;
         }
 
-        PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
+        PlatformMutex_Unlock( &pContext->libStatusMutex );
     }
 
     if( cellularStatus == CELLULAR_SUCCESS )
     {
-        PlatformMutex_Lock( &( pContext->libStatusMutex ) );
+        PlatformMutex_Lock( &pContext->libStatusMutex );
 
         if( ( pContext->bLibShutdown == true ) || ( pContext->bLibClosing == true ) )
         {
@@ -460,7 +460,7 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
 
-        PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
+        PlatformMutex_Unlock( &pContext->libStatusMutex );
     }
 
     return cellularStatus;
@@ -546,7 +546,7 @@ CellularError_t _Cellular_CreateSocketData( CellularContext_t * pContext,
         {
             #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 1 )
             {
-                pSocketData = &( cellularStaticSocketDataTable[ socketId ] );
+                pSocketData = &cellularStaticSocketDataTable[ socketId ];
             }
             #else
             {
@@ -961,7 +961,7 @@ CellularError_t _Cellular_LibInit( CellularHandle_t * pCellularHandle,
             pContext->pCommIntf = pCommInterface;
 
             /* copy the token table. */
-            ( void ) memcpy( &( pContext->tokenTable ), pTokenTable, sizeof( CellularTokenTable_t ) );
+            ( void ) memcpy( &pContext->tokenTable, pTokenTable, sizeof( CellularTokenTable_t ) );
         }
     }
 
@@ -1118,7 +1118,7 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
     else
     {
         /* undefinedRespCallback can be set to NULL to unregister the callback. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->undefinedRespCallback = undefinedRespCallback;
 
         if( pContext->undefinedRespCallback != NULL )
@@ -1130,7 +1130,7 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
             pContext->pUndefinedRespCBContext = NULL;
         }
 
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;
@@ -1152,7 +1152,7 @@ CellularError_t _Cellular_RegisterInputBufferCallback( CellularContext_t * pCont
     else
     {
         /* inputBufferCallback can be set to NULL to unregister the callback. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->inputBufferCallback = inputBufferCallback;
 
         if( pContext->inputBufferCallback != NULL )
@@ -1164,7 +1164,7 @@ CellularError_t _Cellular_RegisterInputBufferCallback( CellularContext_t * pCont
             pContext->pInputBufferCallbackContext = NULL;
         }
 
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;

--- a/source/cellular_common.c
+++ b/source/cellular_common.c
@@ -126,7 +126,7 @@ static CellularContext_t * _Cellular_AllocContext( void )
         {
             #if ( CELLULAR_CONFIG_STATIC_ALLOCATION_CONTEXT == 1 )
             {
-                pContext = &cellularStaticContextTable[ i ];
+                pContext = &( cellularStaticContextTable[ i ] );
             }
             #else
             {
@@ -190,7 +190,7 @@ static CellularError_t libOpen( CellularContext_t * pContext )
 
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Lock( &pContext->libStatusMutex );
+    PlatformMutex_Lock( &( pContext->libStatusMutex ) );
 
     ( CellularPktStatus_t ) _Cellular_AtParseInit( pContext );
     _Cellular_LockAtDataMutex( pContext );
@@ -223,7 +223,7 @@ static CellularError_t libOpen( CellularContext_t * pContext )
         pContext->bLibShutdown = false;
     }
 
-    PlatformMutex_Unlock( &pContext->libStatusMutex );
+    PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
 
     return cellularStatus;
 }
@@ -237,12 +237,12 @@ static void libClose( CellularContext_t * pContext )
 
     configASSERT( pContext != NULL );
 
-    PlatformMutex_Lock( &pContext->libStatusMutex );
+    PlatformMutex_Lock( &( pContext->libStatusMutex ) );
     bOpened = pContext->bLibOpened;
 
     /* Indicate that CellularLib is in the process of closing. */
     pContext->bLibClosing = true;
-    PlatformMutex_Unlock( &pContext->libStatusMutex );
+    PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
 
     if( bOpened == true )
     {
@@ -251,7 +251,7 @@ static void libClose( CellularContext_t * pContext )
         _Cellular_PktHandlerCleanup( pContext );
     }
 
-    PlatformMutex_Lock( &pContext->libStatusMutex );
+    PlatformMutex_Lock( &( pContext->libStatusMutex ) );
     pContext->bLibShutdown = false;
     pContext->bLibOpened = false;
     pContext->bLibClosing = false;
@@ -270,7 +270,7 @@ static void libClose( CellularContext_t * pContext )
         }
     }
 
-    PlatformMutex_Unlock( &pContext->libStatusMutex );
+    PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
     LogDebug( ( "CELLULARLib closed" ) );
 }
 
@@ -280,7 +280,7 @@ static bool _Cellular_CreateLibStatusMutex( CellularContext_t * pContext )
 {
     bool status = false;
 
-    status = PlatformMutex_Create( &pContext->libStatusMutex, false );
+    status = PlatformMutex_Create( &( pContext->libStatusMutex ), false );
 
     return status;
 }
@@ -289,7 +289,7 @@ static bool _Cellular_CreateLibStatusMutex( CellularContext_t * pContext )
 
 static void _Cellular_DestroyLibStatusMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Destroy( &pContext->libStatusMutex );
+    PlatformMutex_Destroy( &( pContext->libStatusMutex ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -440,19 +440,19 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
     }
     else
     {
-        PlatformMutex_Lock( &pContext->libStatusMutex );
+        PlatformMutex_Lock( &( pContext->libStatusMutex ) );
 
         if( pContext->bLibOpened == false )
         {
             cellularStatus = CELLULAR_LIBRARY_NOT_OPEN;
         }
 
-        PlatformMutex_Unlock( &pContext->libStatusMutex );
+        PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
     }
 
     if( cellularStatus == CELLULAR_SUCCESS )
     {
-        PlatformMutex_Lock( &pContext->libStatusMutex );
+        PlatformMutex_Lock( &( pContext->libStatusMutex ) );
 
         if( ( pContext->bLibShutdown == true ) || ( pContext->bLibClosing == true ) )
         {
@@ -460,7 +460,7 @@ CellularError_t _Cellular_CheckLibraryStatus( CellularContext_t * pContext )
             cellularStatus = CELLULAR_INTERNAL_FAILURE;
         }
 
-        PlatformMutex_Unlock( &pContext->libStatusMutex );
+        PlatformMutex_Unlock( &( pContext->libStatusMutex ) );
     }
 
     return cellularStatus;
@@ -546,7 +546,7 @@ CellularError_t _Cellular_CreateSocketData( CellularContext_t * pContext,
         {
             #if ( CELLULAR_CONFIG_STATIC_SOCKET_CONTEXT_ALLOCATION == 1 )
             {
-                pSocketData = &cellularStaticSocketDataTable[ socketId ];
+                pSocketData = &( cellularStaticSocketDataTable[ socketId ] );
             }
             #else
             {
@@ -961,7 +961,7 @@ CellularError_t _Cellular_LibInit( CellularHandle_t * pCellularHandle,
             pContext->pCommIntf = pCommInterface;
 
             /* copy the token table. */
-            ( void ) memcpy( &pContext->tokenTable, pTokenTable, sizeof( CellularTokenTable_t ) );
+            ( void ) memcpy( &( pContext->tokenTable ), pTokenTable, sizeof( CellularTokenTable_t ) );
         }
     }
 
@@ -1118,7 +1118,7 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
     else
     {
         /* undefinedRespCallback can be set to NULL to unregister the callback. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->undefinedRespCallback = undefinedRespCallback;
 
         if( pContext->undefinedRespCallback != NULL )
@@ -1130,7 +1130,7 @@ CellularError_t _Cellular_RegisterUndefinedRespCallback( CellularContext_t * pCo
             pContext->pUndefinedRespCBContext = NULL;
         }
 
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;
@@ -1152,7 +1152,7 @@ CellularError_t _Cellular_RegisterInputBufferCallback( CellularContext_t * pCont
     else
     {
         /* inputBufferCallback can be set to NULL to unregister the callback. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->inputBufferCallback = inputBufferCallback;
 
         if( pContext->inputBufferCallback != NULL )
@@ -1164,7 +1164,7 @@ CellularError_t _Cellular_RegisterInputBufferCallback( CellularContext_t * pCont
             pContext->pInputBufferCallbackContext = NULL;
         }
 
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;

--- a/source/cellular_common_api.c
+++ b/source/cellular_common_api.c
@@ -170,7 +170,7 @@ CellularError_t Cellular_CommonInit( CellularHandle_t * pCellularHandle,
         {
             pContext = ( CellularContext_t * ) ( *pCellularHandle );
 
-            cellularStatus = Cellular_ModuleInit( pContext, &( pContext->pModuleContext ) );
+            cellularStatus = Cellular_ModuleInit( pContext, &pContext->pModuleContext );
 
             if( cellularStatus == CELLULAR_SUCCESS )
             {
@@ -241,10 +241,10 @@ CellularError_t Cellular_CommonRegisterUrcNetworkRegistrationEventCallback( Cell
     }
     else
     {
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->cbEvents.networkRegistrationCallback = networkRegistrationCallback;
         pContext->cbEvents.pNetworkRegistrationCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;
@@ -268,10 +268,10 @@ CellularError_t Cellular_CommonRegisterUrcPdnEventCallback( CellularHandle_t cel
     }
     else
     {
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->cbEvents.pdnEventCallback = pdnEventCallback;
         pContext->cbEvents.pPdnEventCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;
@@ -295,10 +295,10 @@ CellularError_t Cellular_CommonRegisterUrcSignalStrengthChangedCallback( Cellula
     }
     else
     {
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->cbEvents.signalStrengthChangedCallback = signalStrengthChangedCallback;
         pContext->cbEvents.pSignalStrengthChangedCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;
@@ -322,10 +322,10 @@ CellularError_t Cellular_CommonRegisterUrcGenericCallback( CellularHandle_t cell
     }
     else
     {
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->cbEvents.genericCallback = genericCallback;
         pContext->cbEvents.pGenericCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;
@@ -349,10 +349,10 @@ CellularError_t Cellular_CommonRegisterModemEventCallback( CellularHandle_t cell
     }
     else
     {
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->cbEvents.modemEventCallback = modemEventCallback;
         pContext->cbEvents.pModemEventCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
     }
 
     return cellularStatus;

--- a/source/cellular_common_api.c
+++ b/source/cellular_common_api.c
@@ -170,7 +170,7 @@ CellularError_t Cellular_CommonInit( CellularHandle_t * pCellularHandle,
         {
             pContext = ( CellularContext_t * ) ( *pCellularHandle );
 
-            cellularStatus = Cellular_ModuleInit( pContext, &pContext->pModuleContext );
+            cellularStatus = Cellular_ModuleInit( pContext, &( pContext->pModuleContext ) );
 
             if( cellularStatus == CELLULAR_SUCCESS )
             {
@@ -241,10 +241,10 @@ CellularError_t Cellular_CommonRegisterUrcNetworkRegistrationEventCallback( Cell
     }
     else
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->cbEvents.networkRegistrationCallback = networkRegistrationCallback;
         pContext->cbEvents.pNetworkRegistrationCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;
@@ -268,10 +268,10 @@ CellularError_t Cellular_CommonRegisterUrcPdnEventCallback( CellularHandle_t cel
     }
     else
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->cbEvents.pdnEventCallback = pdnEventCallback;
         pContext->cbEvents.pPdnEventCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;
@@ -295,10 +295,10 @@ CellularError_t Cellular_CommonRegisterUrcSignalStrengthChangedCallback( Cellula
     }
     else
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->cbEvents.signalStrengthChangedCallback = signalStrengthChangedCallback;
         pContext->cbEvents.pSignalStrengthChangedCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;
@@ -322,10 +322,10 @@ CellularError_t Cellular_CommonRegisterUrcGenericCallback( CellularHandle_t cell
     }
     else
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->cbEvents.genericCallback = genericCallback;
         pContext->cbEvents.pGenericCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;
@@ -349,10 +349,10 @@ CellularError_t Cellular_CommonRegisterModemEventCallback( CellularHandle_t cell
     }
     else
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->cbEvents.modemEventCallback = modemEventCallback;
         pContext->cbEvents.pModemEventCallbackContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
     }
 
     return cellularStatus;

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -215,12 +215,12 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         LogDebug( ( ">>>>>Start sending [%s]<<<<<", atReq.pAtCmd ) );
 
         /* Fill in request info structure. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktRespCB = atReq.respCallback;
         pContext->pPktUsrData = atReq.pData;
         pContext->PktUsrDataLen = ( uint16_t ) atReq.dataLen;
         pContext->pCurrentCmd = atReq.pAtCmd;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_PktioSendAtCmd( pContext, atReq.pAtCmd, atReq.atCmdType, atReq.pAtRspPrefix );
 
@@ -251,11 +251,11 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         }
 
         /* No command is waiting response. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
         pContext->pktRespCB = NULL;
         pContext->pCurrentCmd = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
         LogDebug( ( "<<<<<Exit sending [%s] status[%d]<<<<<", atReq.pAtCmd, pktStatus ) );
     }
 
@@ -284,9 +284,9 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 
         /* Send the packet. Data send is regarded as CELLULAR_AT_NO_RESULT. Only
          * success or error token is expected in the result. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_RESULT;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         *dataReq.pSentDataLength = _Cellular_PktioSendData( pContext, dataReq.pData, dataReq.dataLen );
 
@@ -334,9 +334,9 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         }
 
         /* Set AT command type to CELLULAR_AT_NO_COMMAND for timeout case here. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         LogDebug( ( "<<<<<Exit sending data ret[%d]>>>>>", pktStatus ) );
     }
@@ -348,14 +348,14 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 
 static void _Cellular_PktHandlerAcquirePktRequestMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Lock( &pContext->pktRequestMutex );
+    PlatformMutex_Lock( &( pContext->pktRequestMutex ) );
 }
 
 /*-----------------------------------------------------------*/
 
 static void _Cellular_PktHandlerReleasePktRequestMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Unlock( &pContext->pktRequestMutex );
+    PlatformMutex_Unlock( &( pContext->pktRequestMutex ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -605,18 +605,18 @@ CellularPktStatus_t _Cellular_AtcmdRequestSuccessToken( CellularContext_t * pCon
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the extra Token table for this AT command. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = pCellularSrcTokenSuccessTable;
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = cellularSrcTokenSuccessTableSize;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the extra Token table for this AT command. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = 0;
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
     }
@@ -644,18 +644,18 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataRecvRequestWithCallback( CellularC
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the data receive prefix. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktDataPrefixCB = pktDataPrefixCallback;
         pContext->pDataPrefixCBContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, timeoutMS );
 
         /* Clear the data receive prefix. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktDataPrefixCB = NULL;
         pContext->pDataPrefixCBContext = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
     }
@@ -686,18 +686,18 @@ CellularPktStatus_t _Cellular_AtcmdDataSend( CellularContext_t * pContext,
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the data send prefix callback. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktDataSendPrefixCB = pktDataSendPrefixCallback;
         pContext->pDataSendPrefixCBContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the data send prefix callback. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pDataSendPrefixCBContext = NULL;
         pContext->pktDataSendPrefixCB = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -749,18 +749,18 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataSendSuccessToken( CellularContext_
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the extra token table. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = pCellularSrcTokenSuccessTable;
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = cellularSrcTokenSuccessTableSize;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the extra token table. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = 0;
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -817,7 +817,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
         /* Check order of the sorted Map. */
         for( i = 0; i < ( tokenMapSize - 1U ); i++ )
         {
-            result = _sortCompareFunc( &pTokenMap[ i ], &pTokenMap[ i + 1U ] );
+            result = _sortCompareFunc( &( pTokenMap[ i ] ), &( pTokenMap[ i + 1U ] ) );
 
             if( result >= 0 )
             {
@@ -854,7 +854,7 @@ bool _Cellular_CreatePktRequestMutex( CellularContext_t * pContext )
 
     if( pContext != NULL )
     {
-        status = PlatformMutex_Create( &pContext->pktRequestMutex, false );
+        status = PlatformMutex_Create( &( pContext->pktRequestMutex ), false );
     }
 
     return status;
@@ -868,7 +868,7 @@ bool _Cellular_CreatePktResponseMutex( CellularContext_t * pContext )
 
     if( pContext != NULL )
     {
-        status = PlatformMutex_Create( &pContext->PktRespMutex, false );
+        status = PlatformMutex_Create( &( pContext->PktRespMutex ), false );
     }
 
     return status;
@@ -880,7 +880,7 @@ void _Cellular_DestroyPktRequestMutex( CellularContext_t * pContext )
 {
     if( pContext != NULL )
     {
-        PlatformMutex_Destroy( &pContext->pktRequestMutex );
+        PlatformMutex_Destroy( &( pContext->pktRequestMutex ) );
     }
 }
 
@@ -890,7 +890,7 @@ void _Cellular_DestroyPktResponseMutex( CellularContext_t * pContext )
 {
     if( pContext != NULL )
     {
-        PlatformMutex_Destroy( &pContext->PktRespMutex );
+        PlatformMutex_Destroy( &( pContext->PktRespMutex ) );
     }
 }
 

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -71,8 +71,8 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
                                                                   uint32_t timeoutMs );
 static void _Cellular_PktHandlerAcquirePktRequestMutex( CellularContext_t * pContext );
 static void _Cellular_PktHandlerReleasePktRequestMutex( CellularContext_t * pContext );
-static int _searchCompareFunc( const void * pInputToken,
-                               const void * pBase );
+static int32_t _searchCompareFunc( const void * pInputToken,
+                                   const void * pBase );
 static int32_t _sortCompareFunc( const void * pElem1Ptr,
                                  const void * pElem2Ptr );
 static CellularPktStatus_t _atParseGetHandler( CellularContext_t * pContext,
@@ -152,7 +152,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
              * leading char. ":" is also checked in Cellular_ATIsPrefixPresent. Remove
              * the leading char and split the string into the following substrings :
              * pInputLine = "+" pTokenPtr + ":" + pSavePtr. */
-            pSavePtr = pInputLine + 1;
+            pSavePtr = &( pInputLine[ 1 ] );
             pTokenPtr = strtok_r( pSavePtr, ":", &pSavePtr );
 
             if( pTokenPtr == NULL )
@@ -182,7 +182,7 @@ static CellularPktStatus_t _processUrcPacket( CellularContext_t * pContext,
             {
                 /* inputWithPrefix is true means the string starts with '+'.
                  * Restore string to "+pTokenPtr:pSavePtr" for callback function. */
-                *( pSavePtr - 1 ) = ':';
+                pSavePtr[ -1 ] = ':';
             }
 
             _Cellular_GenericCallback( pContext, pInputLine );
@@ -360,10 +360,10 @@ static void _Cellular_PktHandlerReleasePktRequestMutex( CellularContext_t * pCon
 
 /*-----------------------------------------------------------*/
 
-static int _searchCompareFunc( const void * pInputToken,
-                               const void * pBase )
+static int32_t _searchCompareFunc( const void * pInputToken,
+                                   const void * pBase )
 {
-    int compareValue = 0;
+    int32_t compareValue = 0;
     const char * pToken = ( const char * ) pInputToken;
     const CellularAtParseTokenMap_t * pBasePtr = ( const CellularAtParseTokenMap_t * ) pBase;
     uint32_t tokenLen = ( uint32_t ) strlen( pInputToken );
@@ -832,8 +832,6 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
             pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
             LogError( ( "AtParseFail URC token table is not sorted" ) );
         }
-
-        configASSERT( finit == true );
 
         for( i = 0; i < tokenMapSize; i++ )
         {

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -203,7 +203,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
 {
     CellularPktStatus_t respCode = CELLULAR_PKT_STATUS_OK;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
-    BaseType_t qRet = pdFALSE;
+    BaseType_t qRet = pdFAIL;
 
     if( atReq.pAtCmd == NULL )
     {
@@ -215,12 +215,12 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         LogDebug( ( ">>>>>Start sending [%s]<<<<<", atReq.pAtCmd ) );
 
         /* Fill in request info structure. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktRespCB = atReq.respCallback;
         pContext->pPktUsrData = atReq.pData;
         pContext->PktUsrDataLen = ( uint16_t ) atReq.dataLen;
         pContext->pCurrentCmd = atReq.pAtCmd;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_PktioSendAtCmd( pContext, atReq.pAtCmd, atReq.atCmdType, atReq.pAtRspPrefix );
 
@@ -233,7 +233,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
             /* Wait for a response. */
             qRet = xQueueReceive( pContext->pktRespQueue, &respCode, pdMS_TO_TICKS( timeoutMS ) );
 
-            if( qRet == pdTRUE )
+            if( qRet == pdPASS )
             {
                 pktStatus = ( CellularPktStatus_t ) respCode;
 
@@ -251,11 +251,11 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         }
 
         /* No command is waiting response. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
         pContext->pktRespCB = NULL;
         pContext->pCurrentCmd = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
         LogDebug( ( "<<<<<Exit sending [%s] status[%d]<<<<<", atReq.pAtCmd, pktStatus ) );
     }
 
@@ -270,7 +270,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 {
     CellularPktStatus_t respCode = CELLULAR_PKT_STATUS_OK;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
-    BaseType_t qStatus = pdFALSE;
+    BaseType_t qStatus = pdFAIL;
     uint32_t sendEndPatternLen = 0U;
 
     if( ( dataReq.pData == NULL ) || ( dataReq.pSentDataLength == NULL ) )
@@ -284,9 +284,9 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 
         /* Send the packet. Data send is regarded as CELLULAR_AT_NO_RESULT. Only
          * success or error token is expected in the result. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_RESULT;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         *dataReq.pSentDataLength = _Cellular_PktioSendData( pContext, dataReq.pData, dataReq.dataLen );
 
@@ -314,7 +314,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
     {
         qStatus = xQueueReceive( pContext->pktRespQueue, &respCode, pdMS_TO_TICKS( timeoutMs ) );
 
-        if( qStatus == pdTRUE )
+        if( qStatus == pdPASS )
         {
             pktStatus = ( CellularPktStatus_t ) respCode;
 
@@ -334,9 +334,9 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         }
 
         /* Set AT command type to CELLULAR_AT_NO_COMMAND for timeout case here. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         LogDebug( ( "<<<<<Exit sending data ret[%d]>>>>>", pktStatus ) );
     }
@@ -348,14 +348,14 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 
 static void _Cellular_PktHandlerAcquirePktRequestMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Lock( &pContext->pktRequestMutex );
+    PlatformMutex_Lock( &( pContext->pktRequestMutex ) );
 }
 
 /*-----------------------------------------------------------*/
 
 static void _Cellular_PktHandlerReleasePktRequestMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Unlock( &pContext->pktRequestMutex );
+    PlatformMutex_Unlock( &( pContext->pktRequestMutex ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -605,18 +605,18 @@ CellularPktStatus_t _Cellular_AtcmdRequestSuccessToken( CellularContext_t * pCon
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the extra Token table for this AT command. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = pCellularSrcTokenSuccessTable;
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = cellularSrcTokenSuccessTableSize;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the extra Token table for this AT command. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = 0;
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
     }
@@ -644,18 +644,18 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataRecvRequestWithCallback( CellularC
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the data receive prefix. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktDataPrefixCB = pktDataPrefixCallback;
         pContext->pDataPrefixCBContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, timeoutMS );
 
         /* Clear the data receive prefix. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktDataPrefixCB = NULL;
         pContext->pDataPrefixCBContext = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
     }
@@ -686,18 +686,18 @@ CellularPktStatus_t _Cellular_AtcmdDataSend( CellularContext_t * pContext,
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the data send prefix callback. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pktDataSendPrefixCB = pktDataSendPrefixCallback;
         pContext->pDataSendPrefixCBContext = pCallbackContext;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the data send prefix callback. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->pDataSendPrefixCBContext = NULL;
         pContext->pktDataSendPrefixCB = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -749,18 +749,18 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataSendSuccessToken( CellularContext_
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the extra token table. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = pCellularSrcTokenSuccessTable;
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = cellularSrcTokenSuccessTableSize;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the extra token table. */
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = 0;
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = NULL;
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -817,7 +817,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
         /* Check order of the sorted Map. */
         for( i = 0; i < ( tokenMapSize - 1U ); i++ )
         {
-            result = _sortCompareFunc( &pTokenMap[ i ], &pTokenMap[ i + 1U ] );
+            result = _sortCompareFunc( &( pTokenMap[ i ] ), &( pTokenMap[ i + 1U ] ) );
 
             if( result >= 0 )
             {
@@ -854,7 +854,7 @@ bool _Cellular_CreatePktRequestMutex( CellularContext_t * pContext )
 
     if( pContext != NULL )
     {
-        status = PlatformMutex_Create( &pContext->pktRequestMutex, false );
+        status = PlatformMutex_Create( &( pContext->pktRequestMutex ), false );
     }
 
     return status;
@@ -868,7 +868,7 @@ bool _Cellular_CreatePktResponseMutex( CellularContext_t * pContext )
 
     if( pContext != NULL )
     {
-        status = PlatformMutex_Create( &pContext->PktRespMutex, false );
+        status = PlatformMutex_Create( &( pContext->PktRespMutex ), false );
     }
 
     return status;
@@ -880,7 +880,7 @@ void _Cellular_DestroyPktRequestMutex( CellularContext_t * pContext )
 {
     if( pContext != NULL )
     {
-        PlatformMutex_Destroy( &pContext->pktRequestMutex );
+        PlatformMutex_Destroy( &( pContext->pktRequestMutex ) );
     }
 }
 
@@ -890,7 +890,7 @@ void _Cellular_DestroyPktResponseMutex( CellularContext_t * pContext )
 {
     if( pContext != NULL )
     {
-        PlatformMutex_Destroy( &pContext->PktRespMutex );
+        PlatformMutex_Destroy( &( pContext->PktRespMutex ) );
     }
 }
 

--- a/source/cellular_pkthandler.c
+++ b/source/cellular_pkthandler.c
@@ -203,7 +203,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
 {
     CellularPktStatus_t respCode = CELLULAR_PKT_STATUS_OK;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
-    BaseType_t qRet = pdFAIL;
+    BaseType_t qRet = pdFALSE;
 
     if( atReq.pAtCmd == NULL )
     {
@@ -215,12 +215,12 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         LogDebug( ( ">>>>>Start sending [%s]<<<<<", atReq.pAtCmd ) );
 
         /* Fill in request info structure. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->pktRespCB = atReq.respCallback;
         pContext->pPktUsrData = atReq.pData;
         pContext->PktUsrDataLen = ( uint16_t ) atReq.dataLen;
         pContext->pCurrentCmd = atReq.pAtCmd;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         pktStatus = _Cellular_PktioSendAtCmd( pContext, atReq.pAtCmd, atReq.atCmdType, atReq.pAtRspPrefix );
 
@@ -233,7 +233,7 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
             /* Wait for a response. */
             qRet = xQueueReceive( pContext->pktRespQueue, &respCode, pdMS_TO_TICKS( timeoutMS ) );
 
-            if( qRet == pdPASS )
+            if( qRet == pdTRUE )
             {
                 pktStatus = ( CellularPktStatus_t ) respCode;
 
@@ -251,11 +251,11 @@ static CellularPktStatus_t _Cellular_AtcmdRequestTimeoutWithCallbackRaw( Cellula
         }
 
         /* No command is waiting response. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
         pContext->pktRespCB = NULL;
         pContext->pCurrentCmd = NULL;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
         LogDebug( ( "<<<<<Exit sending [%s] status[%d]<<<<<", atReq.pAtCmd, pktStatus ) );
     }
 
@@ -270,7 +270,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 {
     CellularPktStatus_t respCode = CELLULAR_PKT_STATUS_OK;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
-    BaseType_t qStatus = pdFAIL;
+    BaseType_t qStatus = pdFALSE;
     uint32_t sendEndPatternLen = 0U;
 
     if( ( dataReq.pData == NULL ) || ( dataReq.pSentDataLength == NULL ) )
@@ -284,9 +284,9 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 
         /* Send the packet. Data send is regarded as CELLULAR_AT_NO_RESULT. Only
          * success or error token is expected in the result. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_RESULT;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         *dataReq.pSentDataLength = _Cellular_PktioSendData( pContext, dataReq.pData, dataReq.dataLen );
 
@@ -314,7 +314,7 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
     {
         qStatus = xQueueReceive( pContext->pktRespQueue, &respCode, pdMS_TO_TICKS( timeoutMs ) );
 
-        if( qStatus == pdPASS )
+        if( qStatus == pdTRUE )
         {
             pktStatus = ( CellularPktStatus_t ) respCode;
 
@@ -334,9 +334,9 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
         }
 
         /* Set AT command type to CELLULAR_AT_NO_COMMAND for timeout case here. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         LogDebug( ( "<<<<<Exit sending data ret[%d]>>>>>", pktStatus ) );
     }
@@ -348,14 +348,14 @@ static CellularPktStatus_t _Cellular_DataSendWithTimeoutDelayRaw( CellularContex
 
 static void _Cellular_PktHandlerAcquirePktRequestMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Lock( &( pContext->pktRequestMutex ) );
+    PlatformMutex_Lock( &pContext->pktRequestMutex );
 }
 
 /*-----------------------------------------------------------*/
 
 static void _Cellular_PktHandlerReleasePktRequestMutex( CellularContext_t * pContext )
 {
-    PlatformMutex_Unlock( &( pContext->pktRequestMutex ) );
+    PlatformMutex_Unlock( &pContext->pktRequestMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -605,18 +605,18 @@ CellularPktStatus_t _Cellular_AtcmdRequestSuccessToken( CellularContext_t * pCon
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the extra Token table for this AT command. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = pCellularSrcTokenSuccessTable;
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = cellularSrcTokenSuccessTableSize;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the extra Token table for this AT command. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = 0;
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = NULL;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
     }
@@ -644,18 +644,18 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataRecvRequestWithCallback( CellularC
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the data receive prefix. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->pktDataPrefixCB = pktDataPrefixCallback;
         pContext->pDataPrefixCBContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, timeoutMS );
 
         /* Clear the data receive prefix. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->pktDataPrefixCB = NULL;
         pContext->pDataPrefixCBContext = NULL;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         _Cellular_PktHandlerReleasePktRequestMutex( pContext );
     }
@@ -686,18 +686,18 @@ CellularPktStatus_t _Cellular_AtcmdDataSend( CellularContext_t * pContext,
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the data send prefix callback. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->pktDataSendPrefixCB = pktDataSendPrefixCallback;
         pContext->pDataSendPrefixCBContext = pCallbackContext;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the data send prefix callback. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->pDataSendPrefixCBContext = NULL;
         pContext->pktDataSendPrefixCB = NULL;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -749,18 +749,18 @@ CellularPktStatus_t _Cellular_TimeoutAtcmdDataSendSuccessToken( CellularContext_
         _Cellular_PktHandlerAcquirePktRequestMutex( pContext );
 
         /* Set the extra token table. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = pCellularSrcTokenSuccessTable;
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = cellularSrcTokenSuccessTableSize;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         pktStatus = _Cellular_AtcmdRequestTimeoutWithCallbackRaw( pContext, atReq, atTimeoutMS );
 
         /* Clear the extra token table. */
-        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Lock( &pContext->PktRespMutex );
         pContext->tokenTable.cellularSrcExtraTokenSuccessTableSize = 0;
         pContext->tokenTable.pCellularSrcExtraTokenSuccessTable = NULL;
-        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
+        PlatformMutex_Unlock( &pContext->PktRespMutex );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -817,7 +817,7 @@ CellularPktStatus_t _Cellular_AtParseInit( const CellularContext_t * pContext )
         /* Check order of the sorted Map. */
         for( i = 0; i < ( tokenMapSize - 1U ); i++ )
         {
-            result = _sortCompareFunc( &( pTokenMap[ i ] ), &( pTokenMap[ i + 1U ] ) );
+            result = _sortCompareFunc( &pTokenMap[ i ], &pTokenMap[ i + 1U ] );
 
             if( result >= 0 )
             {
@@ -854,7 +854,7 @@ bool _Cellular_CreatePktRequestMutex( CellularContext_t * pContext )
 
     if( pContext != NULL )
     {
-        status = PlatformMutex_Create( &( pContext->pktRequestMutex ), false );
+        status = PlatformMutex_Create( &pContext->pktRequestMutex, false );
     }
 
     return status;
@@ -868,7 +868,7 @@ bool _Cellular_CreatePktResponseMutex( CellularContext_t * pContext )
 
     if( pContext != NULL )
     {
-        status = PlatformMutex_Create( &( pContext->PktRespMutex ), false );
+        status = PlatformMutex_Create( &pContext->PktRespMutex, false );
     }
 
     return status;
@@ -880,7 +880,7 @@ void _Cellular_DestroyPktRequestMutex( CellularContext_t * pContext )
 {
     if( pContext != NULL )
     {
-        PlatformMutex_Destroy( &( pContext->pktRequestMutex ) );
+        PlatformMutex_Destroy( &pContext->pktRequestMutex );
     }
 }
 
@@ -890,7 +890,7 @@ void _Cellular_DestroyPktResponseMutex( CellularContext_t * pContext )
 {
     if( pContext != NULL )
     {
-        PlatformMutex_Destroy( &( pContext->PktRespMutex ) );
+        PlatformMutex_Destroy( &pContext->PktRespMutex );
     }
 }
 

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -345,7 +345,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
     ( void ) pRespPrefix;
 
     /* Lock the response mutex when processing the input line. */
-    PlatformMutex_Lock( &pContext->PktRespMutex );
+    PlatformMutex_Lock( &( pContext->PktRespMutex ) );
 
     if( ( pContext->tokenTable.pCellularSrcTokenErrorTable != NULL ) &&
         ( pContext->tokenTable.pCellularSrcTokenSuccessTable != NULL ) )
@@ -408,7 +408,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
                    ( pRespPrefix != NULL ? pRespPrefix : "NULL" ) ) );
     }
 
-    PlatformMutex_Unlock( &pContext->PktRespMutex );
+    PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
     return pkStatus;
 }
@@ -454,7 +454,7 @@ static _atRespType_t _getMsgType( CellularContext_t * pContext,
     bool inputWithSrcPrefix = false;
 
     /* Lock the response mutex when deciding message type. */
-    PlatformMutex_Lock( &pContext->PktRespMutex );
+    PlatformMutex_Lock( &( pContext->PktRespMutex ) );
 
     if( _checkUrcTokenWoPrefix( pContext, pLine ) == true )
     {
@@ -509,7 +509,7 @@ static _atRespType_t _getMsgType( CellularContext_t * pContext,
         }
     }
 
-    PlatformMutex_Unlock( &pContext->PktRespMutex );
+    PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
     return atRespType;
 }
@@ -520,7 +520,7 @@ static CellularCommInterfaceError_t _Cellular_PktRxCallBack( void * pUserData,
                                                              CellularCommInterfaceHandle_t commInterfaceHandle )
 {
     const CellularContext_t * pContext = ( CellularContext_t * ) pUserData;
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE, xResult = pdFALSE;
+    BaseType_t xHigherPriorityTaskWoken = pdFAIL, xResult = pdFAIL;
     CellularCommInterfaceError_t retComm = IOT_COMM_INTERFACE_SUCCESS;
 
     ( void ) commInterfaceHandle; /* Comm if is not used in this function. */
@@ -538,7 +538,7 @@ static CellularCommInterfaceError_t _Cellular_PktRxCallBack( void * pUserData,
 
         if( xResult == pdPASS )
         {
-            if( xHigherPriorityTaskWoken == pdTRUE )
+            if( xHigherPriorityTaskWoken == pdPASS )
             {
                 retComm = IOT_COMM_INTERFACE_SUCCESS;
             }
@@ -571,7 +571,7 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
     pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] = '\0';
 
-    pRead = &pContext->pktioReadBuf[ pContext->partialDataRcvdLen ];
+    pRead = &( pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] );
 
     pContext->pPktioReadPtr = pContext->pktioReadBuf;
 
@@ -611,7 +611,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
         if( pContext->pPktioReadPtr != NULL )
         {
             /* There are still valid data before pPktioReadPtr. */
-            pRead = &pContext->pPktioReadPtr[ pContext->partialDataRcvdLen ];
+            pRead = &( pContext->pPktioReadPtr[ pContext->partialDataRcvdLen ] );
             pAtBuf = pContext->pPktioReadPtr;
             bufferEmptyLength = ( ( int32_t ) PKTIO_READ_BUFFER_SIZE -
                                   ( int32_t ) pContext->partialDataRcvdLen - ( int32_t ) _convertCharPtrDistance( pContext->pPktioReadPtr, pContext->pktioReadBuf ) );
@@ -619,7 +619,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
         else
         {
             /* There are valid data need to be handled with length pContext->partialDataRcvdLen. */
-            pRead = &pContext->pktioReadBuf[ pContext->partialDataRcvdLen ];
+            pRead = &( pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] );
             pAtBuf = pContext->pktioReadBuf;
             bufferEmptyLength = ( ( int32_t ) PKTIO_READ_BUFFER_SIZE - ( int32_t ) pContext->partialDataRcvdLen );
         }
@@ -684,7 +684,7 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         _saveRawData( pStartOfData, pAtResp, pContext->dataLength );
 
         /* Advance pLine to a point after data. */
-        *ppLine = &pStartOfData[ pContext->dataLength ];
+        *ppLine = &( pStartOfData[ pContext->dataLength ] );
 
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
@@ -746,10 +746,10 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
         {
             /* Reset the command type. Further response from cellular modem won't be
              * regarded as AT_SOLICITED response. */
-            PlatformMutex_Lock( &pContext->PktRespMutex );
+            PlatformMutex_Lock( &( pContext->PktRespMutex ) );
             pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
             pContext->pRespPrefix = NULL;
-            PlatformMutex_Unlock( &pContext->PktRespMutex );
+            PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
             /* This command is completed. Call the user callback to parse the result. */
             if( pContext->pPktioHandlepktCB != NULL )
@@ -796,10 +796,10 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
                         ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ) ) );
 
             /* Reset the command type. */
-            PlatformMutex_Lock( &pContext->PktRespMutex );
+            PlatformMutex_Lock( &( pContext->PktRespMutex ) );
             pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
             pContext->pRespPrefix = NULL;
-            PlatformMutex_Unlock( &pContext->PktRespMutex );
+            PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
             /* Clean the read buffer and read pointer. */
             ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
@@ -913,12 +913,12 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
 
     if( pContext->inputBufferCallback != NULL )
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pktStatus = pContext->inputBufferCallback( pContext->pInputBufferCallbackContext,
                                                    pTempLine,
                                                    *pBytesRead,
                                                    &bufferLength );
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -941,7 +941,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
                 /* The input buffer is handled in the callback successfully. Move
                  * the read pointer forward. pktio will keep processing the line
                  * after. */
-                pTempLine = &pTempLine[ bufferLength ];
+                pTempLine = &( pTempLine[ bufferLength ] );
                 *pLine = pTempLine;
                 pContext->pPktioReadPtr = *pLine;
 
@@ -975,12 +975,12 @@ static bool _preprocessLine( CellularContext_t * pContext,
     void * pDataSendPrefixCBContext = NULL;
 
     /* Acquire the response lock to keep consistency. */
-    PlatformMutex_Lock( &pContext->PktRespMutex );
+    PlatformMutex_Lock( &( pContext->PktRespMutex ) );
     pktDataPrefixCB = pContext->pktDataPrefixCB;
     pDataPrefixCBContext = pContext->pDataPrefixCBContext;
     pktDataSendPrefixCB = pContext->pktDataSendPrefixCB;
     pDataSendPrefixCBContext = pContext->pDataSendPrefixCBContext;
-    PlatformMutex_Unlock( &pContext->PktRespMutex );
+    PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
     /* The line only has change line. */
     if( *pBytesRead <= 0U )
@@ -1012,7 +1012,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
              * received are in the same line. */
             pktStatus = pktDataPrefixCB( pDataPrefixCBContext,
                                          pTempLine, *pBytesRead,
-                                         ppStartOfData, &pContext->dataLength );
+                                         ppStartOfData, &( pContext->dataLength ) );
 
             keepProcess = _handleCallbackResult( pContext, pktStatus, pTempLine, pBytesRead );
         }
@@ -1189,7 +1189,7 @@ static uint32_t _handleRxDataEvent( CellularContext_t * pContext )
         {
             /* Add the null terminated char to the end of pLine. */
             pLine[ bytesLeft ] = '\0';
-            _handleAllReceived( pContext, &pContext->pAtCmdResp, pLine, bytesLeft );
+            _handleAllReceived( pContext, &( pContext->pAtCmdResp ), pLine, bytesLeft );
         }
     }
 
@@ -1207,7 +1207,7 @@ static void _pktioReadThread( void * pUserData )
     /* Open main communication port. */
     if( ( pContext->pCommIntf != NULL ) &&
         ( pContext->pCommIntf->open( _Cellular_PktRxCallBack, ( void * ) pContext,
-                                     &pContext->hPktioCommIntf ) == IOT_COMM_INTERFACE_SUCCESS ) )
+                                     &( pContext->hPktioCommIntf ) ) == IOT_COMM_INTERFACE_SUCCESS ) )
     {
         /* Send thread started event. */
         ( void ) PlatformEventGroup_SetBits( ( PlatformEventGroupHandle_t ) pContext->pPktioCommEvent, ( EventBits_t ) PKTIO_EVT_MASK_STARTED );
@@ -1217,8 +1217,8 @@ static void _pktioReadThread( void * pUserData )
             /* Wait events for abort thread or rx data available. */
             uxBits = ( PlatformEventGroup_EventBits ) PlatformEventGroup_WaitBits( ( PlatformEventGroupHandle_t ) pContext->pPktioCommEvent,
                                                                                    ( ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_ABORT | ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_RX_DATA ),
-                                                                                   pdTRUE,
-                                                                                   pdFALSE,
+                                                                                   pdPASS,
+                                                                                   pdFAIL,
                                                                                    portMAX_DELAY );
 
             if( ( uxBits & ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_ABORT ) != 0U )
@@ -1267,8 +1267,8 @@ static void _PktioInitProcessReadThreadStatus( CellularContext_t * pContext )
 
     uxBits = ( PlatformEventGroup_EventBits ) PlatformEventGroup_WaitBits( ( PlatformEventGroupHandle_t ) pContext->pPktioCommEvent,
                                                                            ( ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_STARTED | ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_ABORTED ),
-                                                                           pdTRUE,
-                                                                           pdFALSE,
+                                                                           pdPASS,
+                                                                           pdFAIL,
                                                                            ( ( PlatformTickType ) ~( 0UL ) ) );
 
     if( ( uxBits & ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_ABORTED ) != ( PlatformEventGroup_EventBits ) PKTIO_EVT_MASK_ABORTED )
@@ -1452,7 +1452,7 @@ CellularPktStatus_t _Cellular_PktioSendAtCmd( CellularContext_t * pContext,
         }
         else
         {
-            PlatformMutex_Lock( &pContext->PktRespMutex );
+            PlatformMutex_Lock( &( pContext->PktRespMutex ) );
 
             pktStatus = _setPrefixByAtCommandType( pContext, atType, pAtRspPrefix );
 
@@ -1465,15 +1465,15 @@ CellularPktStatus_t _Cellular_PktioSendAtCmd( CellularContext_t * pContext,
                 ( void ) strncpy( pContext->pktioSendBuf, pAtCmd, cmdLen );
                 pContext->pktioSendBuf[ cmdLen ] = '\r';
 
-                PlatformMutex_Unlock( &pContext->PktRespMutex );
+                PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
                 ( void ) pContext->pCommIntf->send( pContext->hPktioCommIntf,
-                                                    ( const uint8_t * ) &pContext->pktioSendBuf, newCmdLen,
+                                                    ( const uint8_t * ) &( pContext->pktioSendBuf ), newCmdLen,
                                                     CELLULAR_COMM_IF_SEND_TIMEOUT_MS, &sentLen );
             }
             else
             {
-                PlatformMutex_Unlock( &pContext->PktRespMutex );
+                PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
             }
         }
     }

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -345,7 +345,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
     ( void ) pRespPrefix;
 
     /* Lock the response mutex when processing the input line. */
-    PlatformMutex_Lock( &pContext->PktRespMutex );
+    PlatformMutex_Lock( &( pContext->PktRespMutex ) );
 
     if( ( pContext->tokenTable.pCellularSrcTokenErrorTable != NULL ) &&
         ( pContext->tokenTable.pCellularSrcTokenSuccessTable != NULL ) )
@@ -408,7 +408,7 @@ static CellularPktStatus_t _Cellular_ProcessLine( CellularContext_t * pContext,
                    ( pRespPrefix != NULL ? pRespPrefix : "NULL" ) ) );
     }
 
-    PlatformMutex_Unlock( &pContext->PktRespMutex );
+    PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
     return pkStatus;
 }
@@ -454,7 +454,7 @@ static _atRespType_t _getMsgType( CellularContext_t * pContext,
     bool inputWithSrcPrefix = false;
 
     /* Lock the response mutex when deciding message type. */
-    PlatformMutex_Lock( &pContext->PktRespMutex );
+    PlatformMutex_Lock( &( pContext->PktRespMutex ) );
 
     if( _checkUrcTokenWoPrefix( pContext, pLine ) == true )
     {
@@ -509,7 +509,7 @@ static _atRespType_t _getMsgType( CellularContext_t * pContext,
         }
     }
 
-    PlatformMutex_Unlock( &pContext->PktRespMutex );
+    PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
     return atRespType;
 }
@@ -571,7 +571,7 @@ static char * _handleLeftoverBuffer( CellularContext_t * pContext )
     ( void ) memmove( pContext->pktioReadBuf, pContext->pPktioReadPtr, pContext->partialDataRcvdLen );
     pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] = '\0';
 
-    pRead = &pContext->pktioReadBuf[ pContext->partialDataRcvdLen ];
+    pRead = &( pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] );
 
     pContext->pPktioReadPtr = pContext->pktioReadBuf;
 
@@ -611,7 +611,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
         if( pContext->pPktioReadPtr != NULL )
         {
             /* There are still valid data before pPktioReadPtr. */
-            pRead = &pContext->pPktioReadPtr[ pContext->partialDataRcvdLen ];
+            pRead = &( pContext->pPktioReadPtr[ pContext->partialDataRcvdLen ] );
             pAtBuf = pContext->pPktioReadPtr;
             bufferEmptyLength = ( ( int32_t ) PKTIO_READ_BUFFER_SIZE -
                                   ( int32_t ) pContext->partialDataRcvdLen - ( int32_t ) _convertCharPtrDistance( pContext->pPktioReadPtr, pContext->pktioReadBuf ) );
@@ -619,7 +619,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
         else
         {
             /* There are valid data need to be handled with length pContext->partialDataRcvdLen. */
-            pRead = &pContext->pktioReadBuf[ pContext->partialDataRcvdLen ];
+            pRead = &( pContext->pktioReadBuf[ pContext->partialDataRcvdLen ] );
             pAtBuf = pContext->pktioReadBuf;
             bufferEmptyLength = ( ( int32_t ) PKTIO_READ_BUFFER_SIZE - ( int32_t ) pContext->partialDataRcvdLen );
         }
@@ -684,7 +684,7 @@ static CellularPktStatus_t _handleData( char * pStartOfData,
         _saveRawData( pStartOfData, pAtResp, pContext->dataLength );
 
         /* Advance pLine to a point after data. */
-        *ppLine = &pStartOfData[ pContext->dataLength ];
+        *ppLine = &( pStartOfData[ pContext->dataLength ] );
 
         /* There are more bytes after the data. */
         *pBytesLeft = ( bytesDataAndLeft - pContext->dataLength );
@@ -746,10 +746,10 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
         {
             /* Reset the command type. Further response from cellular modem won't be
              * regarded as AT_SOLICITED response. */
-            PlatformMutex_Lock( &pContext->PktRespMutex );
+            PlatformMutex_Lock( &( pContext->PktRespMutex ) );
             pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
             pContext->pRespPrefix = NULL;
-            PlatformMutex_Unlock( &pContext->PktRespMutex );
+            PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
             /* This command is completed. Call the user callback to parse the result. */
             if( pContext->pPktioHandlepktCB != NULL )
@@ -796,10 +796,10 @@ static CellularPktStatus_t _handleMsgType( CellularContext_t * pContext,
                         ( pContext->pCurrentCmd != NULL ? pContext->pCurrentCmd : "NULL" ) ) );
 
             /* Reset the command type. */
-            PlatformMutex_Lock( &pContext->PktRespMutex );
+            PlatformMutex_Lock( &( pContext->PktRespMutex ) );
             pContext->PktioAtCmdType = CELLULAR_AT_NO_COMMAND;
             pContext->pRespPrefix = NULL;
-            PlatformMutex_Unlock( &pContext->PktRespMutex );
+            PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
             /* Clean the read buffer and read pointer. */
             ( void ) memset( pContext->pktioReadBuf, 0, PKTIO_READ_BUFFER_SIZE + 1U );
@@ -913,12 +913,12 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
 
     if( pContext->inputBufferCallback != NULL )
     {
-        PlatformMutex_Lock( &pContext->PktRespMutex );
+        PlatformMutex_Lock( &( pContext->PktRespMutex ) );
         pktStatus = pContext->inputBufferCallback( pContext->pInputBufferCallbackContext,
                                                    pTempLine,
                                                    *pBytesRead,
                                                    &bufferLength );
-        PlatformMutex_Unlock( &pContext->PktRespMutex );
+        PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
@@ -941,7 +941,7 @@ static bool _preprocessInputBuffer( CellularContext_t * pContext,
                 /* The input buffer is handled in the callback successfully. Move
                  * the read pointer forward. pktio will keep processing the line
                  * after. */
-                pTempLine = &pTempLine[ bufferLength ];
+                pTempLine = &( pTempLine[ bufferLength ] );
                 *pLine = pTempLine;
                 pContext->pPktioReadPtr = *pLine;
 
@@ -975,12 +975,12 @@ static bool _preprocessLine( CellularContext_t * pContext,
     void * pDataSendPrefixCBContext = NULL;
 
     /* Acquire the response lock to keep consistency. */
-    PlatformMutex_Lock( &pContext->PktRespMutex );
+    PlatformMutex_Lock( &( pContext->PktRespMutex ) );
     pktDataPrefixCB = pContext->pktDataPrefixCB;
     pDataPrefixCBContext = pContext->pDataPrefixCBContext;
     pktDataSendPrefixCB = pContext->pktDataSendPrefixCB;
     pDataSendPrefixCBContext = pContext->pDataSendPrefixCBContext;
-    PlatformMutex_Unlock( &pContext->PktRespMutex );
+    PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
     /* The line only has change line. */
     if( *pBytesRead <= 0U )
@@ -1012,7 +1012,7 @@ static bool _preprocessLine( CellularContext_t * pContext,
              * received are in the same line. */
             pktStatus = pktDataPrefixCB( pDataPrefixCBContext,
                                          pTempLine, *pBytesRead,
-                                         ppStartOfData, &pContext->dataLength );
+                                         ppStartOfData, &( pContext->dataLength ) );
 
             keepProcess = _handleCallbackResult( pContext, pktStatus, pTempLine, pBytesRead );
         }
@@ -1189,7 +1189,7 @@ static uint32_t _handleRxDataEvent( CellularContext_t * pContext )
         {
             /* Add the null terminated char to the end of pLine. */
             pLine[ bytesLeft ] = '\0';
-            _handleAllReceived( pContext, &pContext->pAtCmdResp, pLine, bytesLeft );
+            _handleAllReceived( pContext, &( pContext->pAtCmdResp ), pLine, bytesLeft );
         }
     }
 
@@ -1207,7 +1207,7 @@ static void _pktioReadThread( void * pUserData )
     /* Open main communication port. */
     if( ( pContext->pCommIntf != NULL ) &&
         ( pContext->pCommIntf->open( _Cellular_PktRxCallBack, ( void * ) pContext,
-                                     &pContext->hPktioCommIntf ) == IOT_COMM_INTERFACE_SUCCESS ) )
+                                     &( pContext->hPktioCommIntf ) ) == IOT_COMM_INTERFACE_SUCCESS ) )
     {
         /* Send thread started event. */
         ( void ) PlatformEventGroup_SetBits( ( PlatformEventGroupHandle_t ) pContext->pPktioCommEvent, ( EventBits_t ) PKTIO_EVT_MASK_STARTED );
@@ -1452,7 +1452,7 @@ CellularPktStatus_t _Cellular_PktioSendAtCmd( CellularContext_t * pContext,
         }
         else
         {
-            PlatformMutex_Lock( &pContext->PktRespMutex );
+            PlatformMutex_Lock( &( pContext->PktRespMutex ) );
 
             pktStatus = _setPrefixByAtCommandType( pContext, atType, pAtRspPrefix );
 
@@ -1465,15 +1465,15 @@ CellularPktStatus_t _Cellular_PktioSendAtCmd( CellularContext_t * pContext,
                 ( void ) strncpy( pContext->pktioSendBuf, pAtCmd, cmdLen );
                 pContext->pktioSendBuf[ cmdLen ] = '\r';
 
-                PlatformMutex_Unlock( &pContext->PktRespMutex );
+                PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
 
                 ( void ) pContext->pCommIntf->send( pContext->hPktioCommIntf,
-                                                    ( const uint8_t * ) &pContext->pktioSendBuf, newCmdLen,
+                                                    ( const uint8_t * ) &( pContext->pktioSendBuf ), newCmdLen,
                                                     CELLULAR_COMM_IF_SEND_TIMEOUT_MS, &sentLen );
             }
             else
             {
-                PlatformMutex_Unlock( &pContext->PktRespMutex );
+                PlatformMutex_Unlock( &( pContext->PktRespMutex ) );
             }
         }
     }

--- a/source/include/private/cellular_common_internal.h
+++ b/source/include/private/cellular_common_internal.h
@@ -106,15 +106,16 @@ struct CellularContext
     const CellularCommInterface_t * pCommIntf; /**<  Communication interface for target specific. */
 
     /* Common library. */
-    bool bLibOpened;                 /**<  CellularLib is currently open. */
-    bool bLibShutdown;               /**<  CellularLib prematurely shut down. */
-    bool bLibClosing;                /**<  Graceful shutdown in progress. */
-    PlatformMutex_t libStatusMutex;  /**<  The mutex for changing lib status. */
-    PlatformMutex_t libAtDataMutex;  /**<  The mutex for AT data in cellular context. */
-    _callbackEvents_t cbEvents;      /**<  Call back functions registered to report events. */
-    cellularAtData_t libAtData;      /**<  Global variables. */
+    CellularATCommandResponse_t * pAtCmdResp; /**<  Solicited response pointer. */
+    bool bLibOpened;                          /**<  CellularLib is currently open. */
+    bool bLibShutdown;                        /**<  CellularLib prematurely shut down. */
+    bool bLibClosing;                         /**<  Graceful shutdown in progress. */
+    PlatformMutex_t libStatusMutex;           /**<  The mutex for changing lib status. */
+    PlatformMutex_t libAtDataMutex;           /**<  The mutex for AT data in cellular context. */
+    _callbackEvents_t cbEvents;               /**<  Call back functions registered to report events. */
+    cellularAtData_t libAtData;               /**<  Global variables. */
 
-    CellularTokenTable_t tokenTable; /**<  Token table to config pkthandler and pktio. */
+    CellularTokenTable_t tokenTable;          /**<  Token table to config pkthandler and pktio. */
 
     /* Packet handler. */
     PlatformMutex_t pktRequestMutex;                               /**<  The mutex for sending request. */

--- a/source/include/private/cellular_common_internal.h
+++ b/source/include/private/cellular_common_internal.h
@@ -145,8 +145,8 @@ struct CellularContext
     CellularUndefinedRespCallback_t undefinedRespCallback;             /**<  Undefined response callback function. */
     void * pUndefinedRespCBContext;                                    /**<  The pCallbackContext passed to CellularUndefinedRespCallback_t. */
     CellularInputBufferCallback_t inputBufferCallback;                 /**<  URC data preprocess callback function. */
-    void * pInputBufferCallbackContext;                                /**<  the callback context passed to inputBufferCallback. */
-    CellularATCommandResponse_t * pAtCmdResp;                          /**<  Solicited response pointer. */
+    void * pInputBufferCallbackContext;                                /**<  The callback context passed to inputBufferCallback. */
+    CellularATCommandResponse_t * pAtCmdResp;                          /**<  The AT command response pointer. */
 
     /* PktIo data handling. */
     uint32_t dataLength;                                              /**<  The data length in pLine. */

--- a/source/include/private/cellular_common_internal.h
+++ b/source/include/private/cellular_common_internal.h
@@ -106,16 +106,15 @@ struct CellularContext
     const CellularCommInterface_t * pCommIntf; /**<  Communication interface for target specific. */
 
     /* Common library. */
-    CellularATCommandResponse_t * pAtCmdResp; /**<  Solicited response pointer. */
-    bool bLibOpened;                          /**<  CellularLib is currently open. */
-    bool bLibShutdown;                        /**<  CellularLib prematurely shut down. */
-    bool bLibClosing;                         /**<  Graceful shutdown in progress. */
-    PlatformMutex_t libStatusMutex;           /**<  The mutex for changing lib status. */
-    PlatformMutex_t libAtDataMutex;           /**<  The mutex for AT data in cellular context. */
-    _callbackEvents_t cbEvents;               /**<  Call back functions registered to report events. */
-    cellularAtData_t libAtData;               /**<  Global variables. */
+    bool bLibOpened;                 /**<  CellularLib is currently open. */
+    bool bLibShutdown;               /**<  CellularLib prematurely shut down. */
+    bool bLibClosing;                /**<  Graceful shutdown in progress. */
+    PlatformMutex_t libStatusMutex;  /**<  The mutex for changing lib status. */
+    PlatformMutex_t libAtDataMutex;  /**<  The mutex for AT data in cellular context. */
+    _callbackEvents_t cbEvents;      /**<  Call back functions registered to report events. */
+    cellularAtData_t libAtData;      /**<  Global variables. */
 
-    CellularTokenTable_t tokenTable;          /**<  Token table to config pkthandler and pktio. */
+    CellularTokenTable_t tokenTable; /**<  Token table to config pkthandler and pktio. */
 
     /* Packet handler. */
     PlatformMutex_t pktRequestMutex;                               /**<  The mutex for sending request. */
@@ -147,6 +146,7 @@ struct CellularContext
     void * pUndefinedRespCBContext;                                    /**<  The pCallbackContext passed to CellularUndefinedRespCallback_t. */
     CellularInputBufferCallback_t inputBufferCallback;                 /**<  URC data preprocess callback function. */
     void * pInputBufferCallbackContext;                                /**<  the callback context passed to inputBufferCallback. */
+    CellularATCommandResponse_t * pAtCmdResp;                          /**<  Solicited response pointer. */
 
     /* PktIo data handling. */
     uint32_t dataLength;                                              /**<  The data length in pLine. */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,12 @@ set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 set( CMAKE_C_STANDARD 90 )
 set( CMAKE_C_STANDARD_REQUIRED ON )
 
+# If no configuration is defined, turn everything on.
+if( NOT DEFINED COV_ANALYSIS AND NOT DEFINED UNITTEST )
+    set( COV_ANALYSIS ON )
+    set( UNITTEST ON )
+endif()
+
 # Do not allow in-source build.
 if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )
     message( FATAL_ERROR "In-source build is not allowed. Please build in a separate directory, such as ${PROJECT_SOURCE_DIR}/build." )
@@ -32,74 +38,86 @@ set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 # ===================================== Coverity Analysis Configuration =================================================
 
 # Set the source path and include path
-set( CELLULAR_COMMON_SOURCE ${MODULE_ROOT_DIR}/source )
-set( CELLULAR_INCLUDE_DIRS ${CELLULAR_COMMON_SOURCE}/include )
+set( CELLULAR_COMMON_SOURCE_DIRS ${MODULE_ROOT_DIR}/source )
+set( CELLULAR_INCLUDE_DIRS ${CELLULAR_COMMON_SOURCE_DIRS}/include )
 set( CELLULAR_COMMON_INCLUDE_DIRS ${CELLULAR_INCLUDE_DIRS}/common )
 set( CELLULAR_COMMON_INCLUDE_PRIVATE_DIRS ${CELLULAR_INCLUDE_DIRS}/private )
-set( CELLULAR_INTERFACE_INCLUDE_DIRS ${CELLULAR_COMMON_SOURCE}/interface )
+set( CELLULAR_INTERFACE_INCLUDE_DIRS ${CELLULAR_COMMON_SOURCE_DIRS}/interface )
 set( CELLULAR_TEST_DIRS ${MODULE_ROOT_DIR}/test/unit-test )
 
-# Target for Coverity analysis that builds the library.
-add_library( coverity_analysis
-             ${CELLULAR_COMMON_SOURCE}/cellular_at_core.c
-             ${CELLULAR_COMMON_SOURCE}/cellular_common.c
-             ${CELLULAR_COMMON_SOURCE}/cellular_common_api.c
-             ${CELLULAR_COMMON_SOURCE}/cellular_3gpp_urc_handler.c
-             ${CELLULAR_COMMON_SOURCE}/cellular_3gpp_api.c
-             ${CELLULAR_COMMON_SOURCE}/cellular_pkthandler.c
-             ${CELLULAR_COMMON_SOURCE}/cellular_pktio.c )
+if( COV_ANALYSIS )
+    # Target for Coverity analysis that builds the library.
+    add_library( coverity_analysis
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_at_core.c
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_common.c
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_common_api.c
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_3gpp_urc_handler.c
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_3gpp_api.c
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_pkthandler.c
+                ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_pktio.c )
 
-# Build Cellular library target without custom config dependency.
-target_compile_definitions( coverity_analysis PUBLIC CELLULAR_DO_NOT_USE_CUSTOM_CONFIG=1 )
+    # Build Cellular library target without custom config dependency.
+    target_compile_definitions( coverity_analysis PUBLIC CELLULAR_DO_NOT_USE_CUSTOM_CONFIG=1 )
 
-# Cellular include path.
-target_include_directories( coverity_analysis PUBLIC ${CELLULAR_COMMON_INCLUDE_DIRS} ${CELLULAR_INCLUDE_DIRS} ${CELLULAR_INTERFACE_INCLUDE_DIRS} ${CELLULAR_TEST_DIRS})
+    # Cellular include path.
+    target_include_directories( coverity_analysis PUBLIC ${CELLULAR_COMMON_INCLUDE_DIRS} ${CELLULAR_INCLUDE_DIRS} ${CELLULAR_INTERFACE_INCLUDE_DIRS} ${CELLULAR_TEST_DIRS} )
 
-# Cellular private include path.
-target_include_directories( coverity_analysis PRIVATE ${CELLULAR_COMMON_INCLUDE_PRIVATE_DIRS} )
+    # Cellular private include path.
+    target_include_directories( coverity_analysis PRIVATE ${CELLULAR_COMMON_INCLUDE_PRIVATE_DIRS} )
 
-# Build without debug enabled when performing static analysis
-target_compile_options(coverity_analysis PUBLIC -DNDEBUG )
+    # Build without debug enabled when performing static analysis
+    target_compile_options( coverity_analysis PUBLIC -DNDEBUG )
+
+    file( GLOB CELLULAR_COMMON_SOURCE ${CELLULAR_COMMON_SOURCE_DIRS}/*.c )
+
+    add_custom_target( fix_source ALL
+                       COMMAND sed -i -b -e 's/pdFALSE/pdFAIL/g' -e 's/pdTRUE/pdPASS/g' ${CELLULAR_COMMON_SOURCE})
+
+    add_dependencies( coverity_analysis fix_source )
+endif()
 
 #  ====================================  Test Configuration ========================================
 
-# Define a CMock resource path.
-set( CMOCK_DIR ${MODULE_ROOT_DIR}/test/unit-test/CMock CACHE INTERNAL "CMock library source directory." )
+if( UNITTEST )
+    # Define a CMock resource path.
+    set( CMOCK_DIR ${MODULE_ROOT_DIR}/test/unit-test/CMock CACHE INTERNAL "CMock library source directory." )
 
-# Include CMock build configuration.
-include( unit-test/cmock_build.cmake )
+    # Include CMock build configuration.
+    include( unit-test/cmock_build.cmake )
 
-# Check if the CMock source directory exists, and if not present, clone the submodule
-# if BUILD_CLONE_SUBMODULES configuration is enabled.
-if( NOT EXISTS ${CMOCK_DIR}/src )
-    # Attempt to clone CMock.
-    if( ${BUILD_CLONE_SUBMODULES} )
-        clone_cmock()
-    else()
-        message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+    # Check if the CMock source directory exists, and if not present, clone the submodule
+    # if BUILD_CLONE_SUBMODULES configuration is enabled.
+    if( NOT EXISTS ${CMOCK_DIR}/src )
+        # Attempt to clone CMock.
+        if( ${BUILD_CLONE_SUBMODULES} )
+            clone_cmock()
+        else()
+            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        endif()
     endif()
+
+    # Add unit test and coverage configuration.
+
+    # Use CTest utility for managing test runs. This has to be added BEFORE
+    # defining test targets with add_test()
+    enable_testing()
+
+    # Add build targets for CMock and Unit, required for unit testing.
+    add_cmock_targets()
+
+    # Add function to enable CMock based tests and coverage.
+    include( ${MODULE_ROOT_DIR}/tools/cmock/create_test.cmake )
+
+    # Include build configuration for unit tests.
+    add_subdirectory( unit-test )
+
+    #  ==================================== Coverage Analysis configuration ========================================
+
+    # Add a target for running coverage on tests.
+    add_custom_target( coverage
+        COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR} -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
+        DEPENDS cmock unity cellular_at_core_utest cellular_pktio_utest cellular_pkthandler_utest cellular_common_api_utest cellular_common_utest cellular_3gpp_api_utest cellular_3gpp_urc_handler_utest
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+
 endif()
-
-# Add unit test and coverage configuration.
-
-# Use CTest utility for managing test runs. This has to be added BEFORE
-# defining test targets with add_test()
-enable_testing()
-
-# Add build targets for CMock and Unit, required for unit testing.
-add_cmock_targets()
-
-# Add function to enable CMock based tests and coverage.
-include( ${MODULE_ROOT_DIR}/tools/cmock/create_test.cmake )
-
-# Include build configuration for unit tests.
-add_subdirectory( unit-test )
-
-#  ==================================== Coverage Analysis configuration ========================================
-
-# Add a target for running coverage on tests.
-add_custom_target( coverage
-    COMMAND ${CMAKE_COMMAND} -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
-    DEPENDS cmock unity cellular_at_core_utest cellular_pktio_utest cellular_pkthandler_utest cellular_common_api_utest cellular_common_utest cellular_3gpp_api_utest cellular_3gpp_urc_handler_utest
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -29,12 +29,12 @@ list(APPEND mock_define_list
 
 # list the files you would like to test here
 list(APPEND real_source_files
-            ${CELLULAR_COMMON_SOURCE}/cellular_at_core.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_pktio.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_pkthandler.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_common_api.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_3gpp_urc_handler.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_3gpp_api.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_at_core.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_pktio.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_pkthandler.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_common_api.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_3gpp_urc_handler.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_3gpp_api.c
         )
 # list the directories the module under test includes
 list(APPEND real_include_directories
@@ -165,9 +165,9 @@ list(APPEND cellular_common_mock_list
 
 # list the files you would like to test here
 list(APPEND cellular_common_real_source_files
-            ${CELLULAR_COMMON_SOURCE}/cellular_common.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_3gpp_urc_handler.c
-            ${CELLULAR_COMMON_SOURCE}/cellular_3gpp_api.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_common.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_3gpp_urc_handler.c
+            ${CELLULAR_COMMON_SOURCE_DIRS}/cellular_3gpp_api.c
         )
 
 set(cellular_common_mock_name "${project_name}_common_mock")

--- a/test/unit-test/cellular_platform.h
+++ b/test/unit-test/cellular_platform.h
@@ -69,6 +69,7 @@
 #define pdFALSE                              ( 0x0 )
 #define pdTRUE                               ( 0x1 )
 #define pdPASS                               ( 0x1 )
+#define pdFAIL                               ( 0x0 )
 
 #define PlatformTickType                     uint32_t
 

--- a/tools/coverity/README.md
+++ b/tools/coverity/README.md
@@ -5,7 +5,7 @@ To that end, this directory provides a [configuration file](https://github.com/F
 building a binary for the tool to analyze.
 
 > **Note**
-For generating the report as outlined below, we have used Coverity version 2018.09.
+For generating the report as outlined below, we have used Coverity version 2023.6.1.
 
 For details regarding the suppressed violations in the report (which can be generated using the instructions described below), please
 see the [MISRA.md](https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md) file.

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -1,74 +1,75 @@
-// MISRA C-2012 Rules
-
 {
-    version : "2.0",
-    standard : "c2012",
-    title: "Coverity MISRA Configuration",
-    deviations : [
-        // Disable the following rules.
+    "version" : "2.0",
+    "standard" : "c2012",
+    "title" : "Coverity MISRA Configuration",
+    "deviations" : [
         {
-            deviation: "Directive 4.5",
-            reason: "Allow names that MISRA considers ambiguous."
+            "deviation" : "Directive 4.5",
+            "reason" : "Allow names that MISRA considers ambiguous."
         },
         {
-            deviation: "Directive 4.8",
-            reason: "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
+            "deviation" : "Directive 4.8",
+            "reason" : "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
         },
         {
-            deviation: "Directive 4.9",
-            reason: "Allow inclusion of function like macros. Logging is done using function like macros."
+            "deviation" : "Directive 4.9",
+            "reason" : "Allow inclusion of function like macros. Logging is done using function like macros."
         },
         {
-            deviation: "Rule 2.4",
-            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+            "deviation" : "Rule 2.3",
+            "reason" : "Allow unused type declaration. These types are used in port implementation."
         },
         {
-            deviation: "Rule 2.5",
-            reason: "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
+            "deviation" : "Rule 2.4",
+            "reason" : "Allow unused tags. Some compilers warn if types are not tagged."
         },
         {
-            deviation: "Rule 3.1",
-            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+            "deviation" : "Rule 2.5",
+            "reason" : "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
         },
         {
-            deviation: "Rule 8.7",
-            reason: "API functions are not used by library. They must be externally visible in order to be used by the application."
+            "deviation" : "Rule 3.1",
+            "reason" : "Allow nested comments. Documentation blocks contain comments for example code."
         },
         {
-            deviation: "Rule 8.9",
-            reason: "Look up table is maintained."
+            "deviation" : "Rule 8.7",
+            "reason" : "API functions are not used by library. They must be externally visible in order to be used by the application."
         },
         {
-            deviation: "Rule 8.13",
-            reason: "The pointer may be updated in some cases."
+            "deviation" : "Rule 8.9",
+            "reason" : "Look up table is maintained."
         },
         {
-            deviation: "Rule 11.5",
-            reason: "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
+            "deviation" : "Rule 8.13",
+            "reason" : "The pointer may be updated in some cases."
         },
         {
-            deviation: "Rule 11.8",
-            reason: "The input const char * pString will be assgined to local variable char * ptrChar, which will be iterated to read the value."
+            "deviation" : "Rule 11.5",
+            "reason" : "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
         },
         {
-            deviation: "Rule 21.1",
-            reason: "Allow use of all names."
+            "deviation" : "Rule 11.8",
+            "reason" : "The input const char * pString will be assgined to local variable char * ptrChar, which will be iterated to read the value."
         },
         {
-            deviation: "Rule 21.2",
-            reason: "Allow use of all names."
+            "deviation" : "Rule 21.1",
+            "reason" : "Allow use of all names."
         },
         {
-            deviation: "Rule 21.3",
-            reason: "This library makes use of malloc. Allow use of malloc."
+            "deviation" : "Rule 21.2",
+            "reason" : "Allow use of all names."
         },
         {
-            deviation: "Rule 21.13",
-            reason: "This library makes use of string functions from ctype.h. Allow usage of those functions"
+            "deviation" : "Rule 21.3",
+            "reason" : "This library makes use of malloc. Allow use of malloc."
         },
         {
-            deviation: "Rule 22.8",
-            reason: "The errno variable must be \"zero\" before calling strtol function."
+            "deviation" : "Rule 21.13",
+            "reason" : "This library makes use of string functions from ctype.h. Allow usage of those functions"
         },
+        {
+            "deviation" : "Rule 22.8",
+            "reason" : "The errno variable must be \"zero\" before calling strtol function."
+        }
     ]
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix MISRA C 2012 deviations

In this PR:
* Adding "UNITTEST" and "COV_ANALYSIS" to align FreeRTOS libraries design
* Fix rule 12.3 not to use comma operator
* Fix rule 13.4 not to use the returned value of the assignment operator
* Fix rule 17.7 for unused return value
* Fix rule 18.4 not to use arithmetic on pointer type
* Fix rule 2.2 to remove overwritten initialized value
* Fix forward NULL warning

Test Steps
-----------
Build coverity_analysis project with coverity 2023.6.1 should show no MISRA deviations.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
