### PR TITLE
Remove const qualifier in CellularPdnConfig_t

### DIFF
--- a/source/include/cellular_types.h
+++ b/source/include/cellular_types.h
@@ -681,11 +681,11 @@ typedef struct CellularIPAddress
  */
 typedef struct CellularPdnConfig
 {
-    CellularPdnContextType_t pdnContextType;                   /**< PDN Context type. */
-    CellularPdnAuthType_t pdnAuthType;                         /**< PDN Authentication type. */
-    const char apnName[ CELLULAR_APN_MAX_SIZE + 1 ];           /**< APN name. */
-    const char username[ CELLULAR_PDN_USERNAME_MAX_SIZE + 1 ]; /**< Username. */
-    const char password[ CELLULAR_PDN_PASSWORD_MAX_SIZE + 1 ]; /**< Password. */
+    CellularPdnContextType_t pdnContextType;             /**< PDN Context type. */
+    CellularPdnAuthType_t pdnAuthType;                   /**< PDN Authentication type. */
+    char apnName[ CELLULAR_APN_MAX_SIZE + 1 ];           /**< APN name. */
+    char username[ CELLULAR_PDN_USERNAME_MAX_SIZE + 1 ]; /**< Username. */
+    char password[ CELLULAR_PDN_PASSWORD_MAX_SIZE + 1 ]; /**< Password. */
 } CellularPdnConfig_t;
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
* Remove const qualifier in CellularPdnConfig_t to allow modify the config after initialized.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
#167 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
