### PR TITLE
Bump CBMC version to 5.95.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
       - name: Set up CBMC runner
         uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main
         with:
-          cbmc_version: "5.61.0"
-          cbmc_viewer_version: "3.5"
+          cbmc_version: "5.95.1"
+          cbmc_viewer_version: "latest"
           kissat_tag: latest
       - run: |
           git submodule update --init --checkout --recursive


### PR DESCRIPTION
Description
-----------
This will make proofs use the latest stable release of CBMC (and cbmc-viewer).

Test Steps
-----------
Tested in CI

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
n/a

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
