### PR TITLE
Fix HTML report generation in ci.yml and release.yml.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DUNITTEST=ON \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG'
 
           make -C build/ all
 
@@ -48,7 +48,7 @@ jobs:
 
           echo -e "::group::${{ env.bashInfo }} Generate Coverage Report ${{ env.bashEnd }}"
           # Generate coverage report, excluding extra directories
-          lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
+          lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
 
           echo "::endgroup::"
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG'
+          -DCMAKE_C_FLAGS='-Wall -Wextra -DNDEBUG'
           make -C build/ all
       - name: Test
         env:


### PR DESCRIPTION
<!--- Title -->
Fix HTML report generation in ci.yml and release.yml.

Description
-----------
<!--- Describe your changes in detail. -->
It fails to generate HTML report in this repo, refer to [line 816 in PR CI result](https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/actions/runs/11912902646/job/33197485869?pr=182#step:5:817). Remove some unnecessary flags in the ci.yml/release.yml to fix the HTML generation.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Follow ci.yml/release.yml commands to generate the coverage report.
```
rm -rf build

cmake -S test -B build/ \
-G "Unix Makefiles" \
-DCMAKE_BUILD_TYPE=Debug \
-DUNITTEST=ON \
-DBUILD_CLONE_SUBMODULES=ON \
-DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG'

make -C build/ all

ctest --test-dir build -E system --output-on-failure

if [ "$?" -eq 0 ]; then
    make -C build/ coverage
    lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
    lcov --rc lcov_branch_coverage=1 --list build/coverage.info
fi
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
