### PR TITLE
Enable typedef to make docs able to link *_t structs.

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -299,7 +299,7 @@ ALIASES                = "dependencies_section{1}=@section \1_dependencies Depen
                          "enums_brief{1}=@brief Enumerated types of the \1." \
                          "functionpointers_group{2}=@defgroup \1_datatypes_functionpointers \2 Function pointer types" \
                          "functionpointers_brief{1}=@brief Function pointer types of the \1." \
-                         "structs_group{21}=@defgroup \1_datatypes_structs \2 Structured types" \
+                         "structs_group{2}=@defgroup \1_datatypes_structs \2 Structured types" \
                          "structs_brief{1}=@brief Structured types of the \1." \
                          "paramstructs_group{2}=@defgroup \1_datatypes_paramstructs \2 Parameter structures" \
                          "paramstructs_brief{2}=@brief Structures passed as parameters to [\2 functions](@ref \1_functions)<br>These structures are passed as parameters to library functions. Documentation for these structures will state the functions associated with each parameter structure and the purpose of each member." \
@@ -478,7 +478,7 @@ INLINE_SIMPLE_STRUCTS  = NO
 # types are typedef'ed and only the typedef is referenced, never the tag name.
 # The default value is: NO.
 
-TYPEDEF_HIDES_STRUCT   = YES
+TYPEDEF_HIDES_STRUCT   = NO
 
 # The size of the symbol lookup cache can be set using LOOKUP_CACHE_SIZE. This
 # cache is used to resolve symbols given their name and scope. Since this can be

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -405,6 +405,11 @@ void PlatformMutex_Unlock( PlatformMutex_t * pMutex );
 */
 
 /**
+ * @structs_group{cellular,Cellular}
+ * @structs_brief{cellular,cellular}
+ */
+
+/**
  * @paramstructs_group{cellular,Cellular}
  * @paramstructs_brief{cellular,cellular}
  */
@@ -422,4 +427,9 @@ void PlatformMutex_Unlock( PlatformMutex_t * pMutex );
 /**
  * @enums_group{cellular,Cellular}
  * @enums_brief{cellular library}
+ */
+
+/**
+ * @common_datatypes_paramstructs_group{cellular,Cellular}
+ * @common_datatypes_paramstructs_brief{cellular library}
  */

--- a/source/include/cellular_types.h
+++ b/source/include/cellular_types.h
@@ -54,10 +54,6 @@
  */
 #define CELLULAR_INVALID_SIGNAL_BAR_VALUE    ( 0xFFU )
 
-/**
- * @ingroup cellular_datatypes_handles
- * @brief Opaque Cellular context structure.
- */
 struct CellularContext;
 
 /**

--- a/source/include/common/cellular_common.h
+++ b/source/include/common/cellular_common.h
@@ -55,7 +55,7 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @ingroup cellular_common_datatypes_paramstructs
+ * @ingroup cellular_datatypes_paramstructs
  * @brief The AT command request structure.
  */
 typedef struct CellularAtReq
@@ -69,7 +69,7 @@ typedef struct CellularAtReq
 } CellularAtReq_t;
 
 /**
- * @ingroup cellular_common_datatypes_paramstructs
+ * @ingroup cellular_datatypes_paramstructs
  * @brief The data command request structure.
  */
 typedef struct CellularAtDataReq
@@ -94,7 +94,7 @@ typedef void ( * CellularAtParseTokenHandler_t )( CellularContext_t * pContext,
                                                   char * pInputStr );
 
 /**
- * @ingroup cellular_common_datatypes_paramstructs
+ * @ingroup cellular_datatypes_paramstructs
  * @brief the URC token and URC handler mapping structure used by pkthandler.
  */
 typedef struct CellularAtParseTokenMap
@@ -116,7 +116,7 @@ typedef enum CellularSocketState
 } CellularSocketState_t;
 
 /**
- * @ingroup cellular_common_datatypes_paramstructs
+ * @ingroup cellular_datatypes_paramstructs
  * @brief Parameters involved in sending/receiving data through sockets.
  */
 typedef struct CellularSocketContext
@@ -151,7 +151,7 @@ typedef struct CellularSocketContext
 } CellularSocketContext_t;
 
 /**
- * @ingroup cellular_common_datatypes_paramstructs
+ * @ingroup cellular_datatypes_paramstructs
  * @brief Parameters to setup pktio and pkthandler token tables.
  */
 typedef struct CellularTokenTable

--- a/source/interface/cellular_comm_interface.h
+++ b/source/interface/cellular_comm_interface.h
@@ -151,6 +151,7 @@ typedef CellularCommInterfaceError_t ( * CellularCommInterfaceRecv_t )( Cellular
 typedef CellularCommInterfaceError_t ( * CellularCommInterfaceClose_t )( CellularCommInterfaceHandle_t commInterfaceHandle );
 
 /**
+ * @ingroup cellular_datatypes_paramstructs
  * @brief Represents the functions of a comm interface.
  *
  * Functions of these signature should be implemented against a comm interface


### PR DESCRIPTION
<!--- Title -->
Enable typedef to make docs able to link *_t structs.

Description
-----------
<!--- Describe your changes in detail. -->
As #184 mentioned, there are some missing handles in the doxygen docs. This PR not only adds handles back, but also enable typedef option in doxygen config to link *_t struct correctly for better user experience.

BEFORE this change: there is no link to the function parameters.
![image](https://github.com/user-attachments/assets/b9a47eac-54ca-4d45-83d2-87a74b11f904)

AFTER this change: and Handles are also fixed
![image](https://github.com/user-attachments/assets/32eb47a1-f392-4385-9f91-fba4b65167d4)

![image](https://github.com/user-attachments/assets/e214a9ce-5844-4f36-bb5f-2bc7f37d2267)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Use `doxygen` to generate the docs locally.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
