### PR TITLE
Add artifact backup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,8 @@ jobs:
           ref: ${{ github.event.inputs.version_number }}
           add_release: "true"
   create-release:
+    permissions:
+      id-token: write
     needs:
       - create-zip
       - deploy-doxygen
@@ -181,3 +183,8 @@ jobs:
             FreeRTOS-Cellular-Interface-${{ github.event.inputs.version_number
             }}.zip
           asset_content_type: application/zip
+      - name: Backup Release Asset
+        uses: FreeRTOS/CI-CD-Github-Actions/artifact-backup@main
+        with:
+          artifact_path: ./FreeRTOS-Cellular-Interface-${{ github.event.inputs.version_number }}.zip
+          release_tag: ${{ github.event.inputs.version_number }}


### PR DESCRIPTION
This PR updates the release workflow to use artifact backup action for storing release artifacts.