### PR TITLE
Limit the number of returned access technology settings

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>cellular_3gpp_api.c</td>
-        <td><center>6.4K</center></td>
+        <td><center>6.5K</center></td>
         <td><center>5.9K</center></td>
     </tr>
     <tr>
@@ -44,7 +44,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>15.3K</center></b></td>
+        <td><b><center>15.4K</center></b></td>
         <td><b><center>13.9K</center></b></td>
     </tr>
 </table>

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1390,7 +1390,7 @@ static CellularPktStatus_t _Cellular_RecvFuncGetEidrxSettings( CellularContext_t
             {
                 LogDebug( ( "GetEidrx: empty EDRXS setting %s", pInputLine ) );
             }
-            else
+            else if( count < CELLULAR_EDRX_LIST_MAX_SIZE )
             {
                 atCoreStatus = parseEidrxLine( pInputLine, count, pEidrxSettingsList );
                 pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
@@ -1399,6 +1399,11 @@ static CellularPktStatus_t _Cellular_RecvFuncGetEidrxSettings( CellularContext_t
                 {
                     count++;
                 }
+            }
+            else
+            {
+                LogError( ( "GetEidrx: eidrxList is full, CELLULAR_EDRX_LIST_MAX_SIZE=%u", CELLULAR_EDRX_LIST_MAX_SIZE ) );
+                pktStatus = CELLULAR_PKT_STATUS_SIZE_MISMATCH;
             }
 
             pCommnadItem = pCommnadItem->pNext;

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1300,6 +1300,8 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
     char * pLocalInputLine = pInputLine;
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
     uint8_t tokenIndex = 0;
+    
+    CELLULAR_CONFIG_ASSERT( count < CELLULAR_EDRX_LIST_MAX_SIZE );
 
     atCoreStatus = Cellular_ATRemovePrefix( &pLocalInputLine );
 

--- a/source/cellular_3gpp_api.c
+++ b/source/cellular_3gpp_api.c
@@ -1300,7 +1300,7 @@ static CellularATError_t parseEidrxLine( char * pInputLine,
     char * pLocalInputLine = pInputLine;
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
     uint8_t tokenIndex = 0;
-    
+
     CELLULAR_CONFIG_ASSERT( count < CELLULAR_EDRX_LIST_MAX_SIZE );
 
     atCoreStatus = Cellular_ATRemovePrefix( &pLocalInputLine );

--- a/test/unit-test/cellular_3gpp_api_utest.c
+++ b/test/unit-test/cellular_3gpp_api_utest.c
@@ -732,6 +732,22 @@ CellularPktStatus_t Mock_AtcmdRequestWithCallback__Cellular_Cellular_RecvFuncGet
         _saveData( pLine2, &atResp, sizeof( pLine2 ) );
         pktStatus = atReq.respCallback( pContext, &atResp, &cellularEidrxSettingsList, sizeof( CELLULAR_EDRX_LIST_MAX_SIZE ) );
     }
+    else if( cbCondition == 5 )
+    {
+        /* Create CELLULAR_EDRX_LIST_MAX_SIZE + 1 parseable lines to exercise the
+         * bounds check.  The callback must cap count at CELLULAR_EDRX_LIST_MAX_SIZE
+         * and not write past the end of the eidrxList array. */
+        char pLines[ CELLULAR_EDRX_LIST_MAX_SIZE + 1 ][ sizeof( CELLULAR_SAMPLE_PREFIX_STRING_INPUT ) ];
+        uint8_t i;
+
+        for( i = 0; i < CELLULAR_EDRX_LIST_MAX_SIZE + 1; i++ )
+        {
+            memcpy( pLines[ i ], CELLULAR_SAMPLE_PREFIX_STRING_INPUT, sizeof( CELLULAR_SAMPLE_PREFIX_STRING_INPUT ) );
+            _saveData( pLines[ i ], &atResp, sizeof( pLines[ i ] ) );
+        }
+
+        pktStatus = atReq.respCallback( pContext, &atResp, &cellularEidrxSettingsList, CELLULAR_EDRX_LIST_MAX_SIZE );
+    }
 
     return pktStatus;
 }
@@ -1842,6 +1858,36 @@ void test_Cellular_CommonGetEidrxSettings_Cb_Cellular_RecvFuncGetEidrxSettings_H
     _Cellular_TranslatePktStatus_IgnoreAndReturn( CELLULAR_SUCCESS );
     cellularStatus = Cellular_CommonGetEidrxSettings( cellularHandle, &eidrxSettingsList );
     TEST_ASSERT_EQUAL( CELLULAR_SUCCESS, cellularStatus );
+}
+
+/**
+ * @brief Test that _Cellular_RecvFuncGetEidrxSettings returns an error and does
+ * not write past eidrxList when the modem returns more than
+ * CELLULAR_EDRX_LIST_MAX_SIZE +CEDRXS lines.
+ */
+void test_Cellular_CommonGetEidrxSettings_Cb_Cellular_RecvFuncGetEidrxSettings_Overflow_Capped( void )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularContext_t context;
+
+    memset( &context, 0, sizeof( CellularContext_t ) );
+    CellularHandle_t cellularHandle = &context;
+    CellularEidrxSettingsList_t eidrxSettingsList;
+
+    memset( &eidrxSettingsList, 0, sizeof( CellularEidrxSettingsList_t ) );
+
+    _Cellular_CheckLibraryStatus_IgnoreAndReturn( CELLULAR_SUCCESS );
+    _Cellular_IsValidPdn_IgnoreAndReturn( CELLULAR_SUCCESS );
+    cbCondition = 5;
+    _Cellular_AtcmdRequestWithCallback_StubWithCallback( Mock_AtcmdRequestWithCallback__Cellular_Cellular_RecvFuncGetEidrxSettings );
+    Cellular_ATRemovePrefix_IgnoreAndReturn( CELLULAR_AT_SUCCESS );
+    Cellular_ATRemoveAllDoubleQuote_IgnoreAndReturn( CELLULAR_AT_SUCCESS );
+    Cellular_ATGetNextTok_StubWithCallback( Mock_Cellular_ATGetNextTok_Calback );
+    Cellular_ATStrtoi_IgnoreAndReturn( CELLULAR_AT_SUCCESS );
+    _Cellular_TranslateAtCoreStatus_IgnoreAndReturn( CELLULAR_PKT_STATUS_OK );
+    _Cellular_TranslatePktStatus_ExpectAndReturn( CELLULAR_PKT_STATUS_SIZE_MISMATCH, CELLULAR_INTERNAL_FAILURE );
+    cellularStatus = Cellular_CommonGetEidrxSettings( cellularHandle, &eidrxSettingsList );
+    TEST_ASSERT_EQUAL( CELLULAR_INTERNAL_FAILURE, cellularStatus );
 }
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Respect the maximum list size of eRDX configurations.

In the case of a cellular modem returning more eRDX settings through the `AT+CEDRXS?` query, the current library would write out of bounds. This would only happen in two cases:
* misconfiguration - you should match the max eRDX settings to the chip through the `CELLULAR_EDRX_LIST_MAX_SIZE` macros
* MITM attack - where the attacker intercepts the hardwired communication and returns a deliberately oversized response.

Test Steps
-----------
Unit test added

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
